### PR TITLE
Split language into bazel and starlark

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Change Log
 
-## 0.2.0 
+## [Unreleased]
 
 - Implement HoverProvider for symbols in starlark files.  If the word is a
   builtin function call a tooltip is provided with a link to the bazel

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
 		"Snippets"
 	],
 	"activationEvents": [
+		"onLanguage:bazel",
 		"onLanguage:starlark"
 	],
 	"engines": {
@@ -30,41 +31,54 @@
 	},
 	"contributes": {
 		"grammars": [
-            {
-                "language": "starlark",
-                "scopeName": "source.starlark",
-                "path": "./syntaxes/starlark.tmLanguage.json"
-            }
-        ],
-        "languages": [
-            {
-                "id": "starlark",
-                "aliases": [
-                    "Starlark",
-                    "starlark",
-                    "Bazel"
-                ],
-                "extensions": [
-					".BUILD",
-					".bazel",
-                    ".WORKSPACE",
-                    ".bzl",
-                    ".sky",
-                    ".star"
-                ],
-                "filenames": [
-                    "BUILD",
-                    "BUILD.bazel",
-                    "WORKSPACE",
-                    "WORKSPACE.bazel"
-                ],
-                "configuration": "./syntaxes/starlark.configuration.json"
-            }
-        ],
-		"snippets": [
 			{
 				"language": "starlark",
-				"path": "./snippets/starlark.json"
+				"scopeName": "source.starlark",
+				"path": "./syntaxes/starlark.tmLanguage.json"
+			},
+			{
+				"language": "bazel",
+				"scopeName": "source.bazel",
+				"path": "./syntaxes/bazel.tmLanguage.json"
+			}
+		],
+		"languages": [
+			{
+				"id": "starlark",
+				"aliases": [
+					"Starlark",
+					"starlark"
+				],
+				"extensions": [
+					".sky",
+					".star"
+				],
+				"configuration": "./syntaxes/starlark.configuration.json"
+			},
+			{
+				"id": "bazel",
+				"aliases": [
+					"Bazel"
+				],
+				"extensions": [
+					".BUILD",
+					".bazel",
+					".WORKSPACE",
+					".bzl"
+				],
+				"filenames": [
+					"BUILD",
+					"BUILD.bazel",
+					"WORKSPACE",
+					"WORKSPACE.bazel"
+				],
+				"configuration": "./syntaxes/bazel.configuration.json"
+			}
+		],
+		"snippets": [
+			{
+				"language": "bazel",
+				"path": "./snippets/bazel.json"
 			}
 		]
 	},

--- a/src/bazelDocGroupHover.ts
+++ b/src/bazelDocGroupHover.ts
@@ -6,14 +6,14 @@ const bazelDocsPrefix = "https://docs.bazel.build/versions/master";
  * A type that captures the name of a group, the items it contains, and the
  * relative path where the documentation exists.
  */
-type StarlarkDocGroup = {
+type BazelDocGroup = {
     name: string,
     path: string,
     items: string[],
     also?: string[],
 };
 
-const bazelDocGroups: StarlarkDocGroup[] = [
+const bazelDocGroups: BazelDocGroup[] = [
     {
         name: "general rules",
         path: "be/general.html",
@@ -115,8 +115,8 @@ const bazelDocGroups: StarlarkDocGroup[] = [
     },
 ];
 
-function makeGroupMap(groups: StarlarkDocGroup[]): Map<string,StarlarkDocGroup> {
-    const groupMap = new Map<string,StarlarkDocGroup>();
+function makeGroupMap(groups: BazelDocGroup[]): Map<string,BazelDocGroup> {
+    const groupMap = new Map<string,BazelDocGroup>();
     for (const group of groups) {
         for (const entry of group.items) {
             groupMap.set(entry, group);
@@ -128,30 +128,30 @@ function makeGroupMap(groups: StarlarkDocGroup[]): Map<string,StarlarkDocGroup> 
 /**
  * Provide a hover for Starlark files and the rule definitions therein.
  */
-export class StarlarkDocGroupHover implements vscode.HoverProvider {
+export class BazelDocGroupHover implements vscode.HoverProvider {
 
-    groups: Map<string,StarlarkDocGroup> = makeGroupMap(bazelDocGroups);
+    groups: Map<string,BazelDocGroup> = makeGroupMap(bazelDocGroups);
 
     public provideHover(
         document: vscode.TextDocument, position: vscode.Position, _token: vscode.CancellationToken
     ): Thenable<vscode.Hover> {
-        console.log(`StarlarkHover: provideHover @ ${JSON.stringify(position)}`);
+        // console.log(`StarlarkHover: provideHover @ ${JSON.stringify(position)}`);
 
         const range: vscode.Range | undefined = document.getWordRangeAtPosition(position);
         if (range === undefined) {
-            console.log(`StarlarkHover: no range`, position);
+            // console.log(`StarlarkHover: no range`, position);
             return Promise.reject<vscode.Hover>();
         }
 
         const word = document.getText(range);
         if (!word) {
-            console.log(`StarlarkHover: no word`, position);
+            // console.log(`StarlarkHover: no word`, position);
             return Promise.reject<vscode.Hover>();
         }
 
         const nextChar = document.getText(new vscode.Range(range.end, range.end.translate(0, +1)));
         if (nextChar !== "(") {
-            console.log(`StarlarkHover: word does not look like a function call: ${nextChar}`);
+            // console.log(`StarlarkHover: word does not look like a function call: ${nextChar}`);
             return Promise.reject<vscode.Hover>();
         }
 
@@ -160,7 +160,7 @@ export class StarlarkDocGroupHover implements vscode.HoverProvider {
             return Promise.resolve<vscode.Hover>(makeBazelDocGroupHover(word, group));
         }
 
-        console.log(`StarlarkHover no match: ${word}`);
+        // console.log(`StarlarkHover no match: ${word}`);
         return Promise.reject<vscode.Hover>();
     }
 
@@ -173,7 +173,7 @@ export class StarlarkDocGroupHover implements vscode.HoverProvider {
  * @param item The name of the item
  * @param group The group to which the item belongs
  */
-function makeBazelDocGroupHover(item: string, group: StarlarkDocGroup): vscode.Hover {
+function makeBazelDocGroupHover(item: string, group: BazelDocGroup): vscode.Hover {
     return new vscode.Hover(makeBazelDocGroupHoverMarkdown(item, group));
 }
 
@@ -183,7 +183,7 @@ function makeBazelDocGroupHover(item: string, group: StarlarkDocGroup): vscode.H
  * @param item The name of the item
  * @param group The group to which the item belongs
  */
-export function makeBazelDocGroupHoverMarkdown(item: string, group: StarlarkDocGroup): vscode.MarkdownString {
+export function makeBazelDocGroupHoverMarkdown(item: string, group: BazelDocGroup): vscode.MarkdownString {
     let lines: string[] = [];
     lines.push(`${makeDocEntryLink(item, group)} a member of the group **${group.name}**`);
     lines.push("");
@@ -207,6 +207,6 @@ export function makeBazelDocGroupHoverMarkdown(item: string, group: StarlarkDocG
  * @param group The group to which the item belongs
  */
 
-export function makeDocEntryLink(item: string, group: StarlarkDocGroup): string {
+export function makeDocEntryLink(item: string, group: BazelDocGroup): string {
     return `[${item}](${bazelDocsPrefix}/${group.path}#${item})`;
 }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1,11 +1,11 @@
 import * as vscode from 'vscode';
-import { StarlarkDocGroupHover } from "./starlarkDocGroupHover";
+import { BazelDocGroupHover } from "./bazelDocGroupHover";
 
 export function activate(context: vscode.ExtensionContext) {
 	context.subscriptions.push(
 		vscode.languages.registerHoverProvider(
-			{ scheme: 'file', language: 'starlark' }, 
-			new StarlarkDocGroupHover(),
+			{ scheme: 'file', language: 'bazel' }, 
+			new BazelDocGroupHover(),
 		),
 	);
 }

--- a/src/test/unit/bazelDocGroupHover.test.ts
+++ b/src/test/unit/bazelDocGroupHover.test.ts
@@ -4,7 +4,7 @@
  *--------------------------------------------------------*/
 
 import * as assert from 'assert';
-import { makeDocEntryLink, makeBazelDocGroupHoverMarkdown } from '../../starlarkDocGroupHover';
+import { makeDocEntryLink, makeBazelDocGroupHoverMarkdown } from '../../bazelDocGroupHover';
 
 suite('StarlarkDocGroup Tests', () => {
 

--- a/syntaxes/bazel.configuration.json
+++ b/syntaxes/bazel.configuration.json
@@ -1,0 +1,32 @@
+{
+    "comments": {
+        "lineComment": "#"
+    },
+    "brackets": [
+        ["{", "}"],
+        ["[", "]"],
+        ["(", ")"]
+    ],
+    "autoClosingPairs": [
+        ["{", "}"],
+        ["[", "]"],
+        ["(", ")"],
+        {
+            "open": "\"",
+            "close": "\"",
+            "notIn": ["string", "comment"]
+        },
+        {
+            "open": "'",
+            "close": "'",
+            "notIn": ["string", "comment"]
+        }
+    ],
+    "surroundingPairs": [
+        ["{", "}"],
+        ["[", "]"],
+        ["(", ")"],
+        ["\"", "\""],
+        ["'", "'"]
+    ]
+}

--- a/syntaxes/bazel.tmLanguage.json
+++ b/syntaxes/bazel.tmLanguage.json
@@ -1,9 +1,13 @@
 {
-    "name": "Starlark",
-    "scopeName": "source.starlark",
+    "name": "Bazel",
+    "scopeName": "source.bazel",
     "fileTypes": [
-        "sky",
-        "star"
+        "BUILD",
+        "WORKSPACE",
+        "bzl",
+        "BUILD.bazel",
+        "WORKSPACE",
+        "WORKSPACE.bazel"
     ],
     "patterns": [
         {

--- a/syntaxes/bazel.tmLanguage.license
+++ b/syntaxes/bazel.tmLanguage.license
@@ -1,0 +1,26 @@
+bazel.tmLanguage.json is derived from MagicPython.tmLanguage.json,
+which can be found at https://github.com/MagicStack/MagicPython.
+
+---
+
+The MIT License
+
+Copyright (c) 2015 MagicStack Inc.  http://magic.io
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.

--- a/syntaxes/bazelrc.configuration.json
+++ b/syntaxes/bazelrc.configuration.json
@@ -1,0 +1,32 @@
+{
+    "comments": {
+        "lineComment": "#"
+    },
+    "brackets": [
+        ["{", "}"],
+        ["[", "]"],
+        ["(", ")"]
+    ],
+    "autoClosingPairs": [
+        ["{", "}"],
+        ["[", "]"],
+        ["(", ")"],
+        {
+            "open": "\"",
+            "close": "\"",
+            "notIn": ["string", "comment"]
+        },
+        {
+            "open": "'",
+            "close": "'",
+            "notIn": ["string", "comment"]
+        }
+    ],
+    "surroundingPairs": [
+        ["{", "}"],
+        ["[", "]"],
+        ["(", ")"],
+        ["\"", "\""],
+        ["'", "'"]
+    ]
+}

--- a/syntaxes/bazelrc.tmLanguage.json
+++ b/syntaxes/bazelrc.tmLanguage.json
@@ -1,9 +1,8 @@
 {
-    "name": "Starlark",
-    "scopeName": "source.starlark",
+    "name": "Bazelrc",
+    "scopeName": "source.bazelrc",
     "fileTypes": [
-        "sky",
-        "star"
+        "bazelrc"
     ],
     "patterns": [
         {

--- a/syntaxes/bazelrc.tmLanguage.license
+++ b/syntaxes/bazelrc.tmLanguage.license
@@ -1,0 +1,26 @@
+starlark.tmLanguage.json is derived from MagicPython.tmLanguage.json,
+which can be found at https://github.com/MagicStack/MagicPython.
+
+---
+
+The MIT License
+
+Copyright (c) 2015 MagicStack Inc.  http://magic.io
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.


### PR DESCRIPTION
Types of completion and features are different for bazel subtype of starlark.  Language name 'bazel' chosen as it is defined in vscode-icons.