### PR TITLE
Make globalStoragePath directory if not exists

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+node_modules
+out
+.vscode

--- a/src/buildifier/feature.ts
+++ b/src/buildifier/feature.ts
@@ -28,7 +28,7 @@ export class BuildifierFeature implements IExtensionFeature {
             try {
                 cfg.executable = await this.maybeInstallBuildifier(cfg, ctx.globalStoragePath);
             } catch (err) {
-                return fail(this, `could not install buildifier: ${JSON.stringify(err)}`);
+                return fail(this, `could not install buildifier ${err}`);
             }
         }
 
@@ -76,7 +76,7 @@ export class BuildifierFeature implements IExtensionFeature {
         if (cfg.verbose > 0) {
             info(this, `downloading ${assetName} ${cfg.releaseTag} to ${executable}`);
         }
-
+        
         return downloader.download();
     }
 

--- a/src/download.ts
+++ b/src/download.ts
@@ -3,6 +3,7 @@
 import * as vscode from 'vscode';
 import * as fs from 'fs';
 import * as path from 'path';
+
 import downloadReleases from "@etclabscore/dl-github-releases";
 
 export class GitHubReleaseAssetDownloader {
@@ -13,21 +14,6 @@ export class GitHubReleaseAssetDownloader {
         private assetName: string,
         private outputDir: string,
         private executable: boolean) {
-    }
-
-    // The ts.d does not seem to want an argument, so we fallback to 'arguments'
-    // to make tsc happy.
-    filterRelease(): boolean {
-        const release = arguments[0];
-        return release.tag_name === this.releaseTag;
-    }
-
-    // The ts.d does not seem to want an argument, so we fallback to 'arguments'
-    // to make tsc happy.
-    filterAsset() {
-        const asset = arguments[0];
-        // console.log(`checking asset`, asset);
-        return asset.name === this.assetName;
     }
 
     /**
@@ -43,20 +29,62 @@ export class GitHubReleaseAssetDownloader {
      */
     download(): Promise<string> {
         const filepath = this.getFilepath();
+        const dirname = path.dirname(filepath);
+        fs.mkdirSync(dirname, {
+            recursive: true,
+        });
 
         return new Promise((resolve, reject) => {
-            downloadReleases(this.owner, this.repo, this.outputDir, this.filterRelease, this.filterAsset)
-                .then(() => {
-                    if (this.executable) {
-                        fs.chmodSync(filepath, "755");
-                    }
-                    vscode.window.showInformationMessage(
-                        `${this.assetName} ${this.releaseTag} installed & ready`,
-                    );
-                    resolve(filepath);
-                })
+            downloadReleases(
+                this.owner,
+                this.repo,
+                this.outputDir,
+                withArgumentPropertyValue("tag_name", this.releaseTag),
+                withArgumentPropertyValue("name", this.assetName),
+            ).then(() => {
+                if (!fs.existsSync(filepath)) {
+                    throw new Error(`Downloader should have created file <${filepath}>.  `
+                        + `Please check that release `
+                        + `https://github.com/${this.owner}/${this.repo}/releases/${this.releaseTag} `
+                        + `has an asset named "${this.assetName}".  `
+                        + `If the release does not exist, check your extension settings.  `
+                        + `If the release exists and asset exists this is likely a bug.  `
+                        + `Please file an issue at https://github.com/stackb/bazel-stack-vscode/issues`);
+                }
+                if (this.executable) {
+                    fs.chmodSync(filepath, "755");
+                }
+                vscode.window.showInformationMessage(
+                    `${this.assetName} ${this.releaseTag} installed & ready`,
+                );
+                resolve(filepath);
+            })
                 .catch(err => reject(err));
         });
     }
 
 }
+
+/**
+ * Return a function that expects a single (json-like) argument and checks that
+ * the named property matches the expected value.  We use this convoluted
+ * approach to make tsc happy because the definition of the filterRelease and
+ * filterAsset signature of the downloadRelease function don't seem to want an
+ * argument even though they actually do.
+ *
+ * @param name The property name to be accessed
+ * @param value The expected value of the property
+ */
+function withArgumentPropertyValue(name: string, value: string): () => boolean {
+    return function(): boolean {
+        if (!arguments.length) {
+            throw new Error(`Expected filter function to be provided at least one argument`);
+        }
+        const obj = arguments[0];
+        if (obj[name] === value) {
+            return true;
+        }
+        return false;
+    }
+}
+


### PR DESCRIPTION
Fixes bug on windows when the globalStorage path does not exist.