### PR TITLE
fix missing include in bazelrc tmLanguage

### DIFF
--- a/syntaxes/bazelrc.tmLanguage.json
+++ b/syntaxes/bazelrc.tmLanguage.json
@@ -169,7 +169,7 @@
                     "include": "#string-illegal-escape-sequence"
                 },
                 {
-                    "include": "#discouraged-string-line-continuation"
+                    "include": "#discouraged-line-continuation"
                 },
                 {
                     "include": "#string-format-placeholder-percent"


### PR DESCRIPTION
without this I am getting this in my text editor (vs code is slightly more lenient on malformed tmlanguages):

```console
$ ./venv/bin/babi-textmate-demo testdata/.bazelrc

# example comment

common:ci --color=no
build:ci --verbose_failures
Traceback (most recent call last):
  File "./venv/bin/babi-textmate-demo", line 8, in <module>
    sys.exit(main())
  File "/tmp/babi-grammars/venv/lib/python3.8/site-packages/babi/textmate_demo.py", line 65, in main
    return _highlight_output(theme, compiler, args.filename)
  File "/tmp/babi-grammars/venv/lib/python3.8/site-packages/babi/textmate_demo.py", line 43, in _highlight_output
    state, regions = highlight_line(compiler, state, line, first_line)
  File "/tmp/babi-grammars/venv/lib/python3.8/site-packages/babi/highlight.py", line 782, in highlight_line
    search_res = state.cur.rule.search(
  File "/tmp/babi-grammars/venv/lib/python3.8/site-packages/babi/highlight.py", line 394, in search
    return _do_regset(idx, match, self, compiler, state, pos)
  File "/tmp/babi-grammars/venv/lib/python3.8/site-packages/babi/highlight.py", line 363, in _do_regset
    target_rule = compiler.compile_rule(rule.u_rules[idx])
  File "/tmp/babi-grammars/venv/lib/python3.8/site-packages/babi/highlight.py", line 663, in compile_rule
    ret = self._c_rules[rule] = self._compile_rule(grammar, rule)
  File "/tmp/babi-grammars/venv/lib/python3.8/site-packages/babi/highlight.py", line 631, in _compile_rule
    regs, rules = self._patterns(grammar, rule.patterns)
  File "/tmp/babi-grammars/venv/lib/python3.8/site-packages/babi/highlight.py", line 595, in _patterns
    tmp_regs, tmp_rules = self._include(
  File "/tmp/babi-grammars/venv/lib/python3.8/site-packages/babi/highlight.py", line 576, in _include
    return self._patterns(grammar, (repository[s[1:]],))
  File "/tmp/babi-grammars/venv/lib/python3.8/site-packages/babi/highlight.py", line 601, in _patterns
    tmp_regs, tmp_rules = self._patterns(grammar, rule.patterns)
  File "/tmp/babi-grammars/venv/lib/python3.8/site-packages/babi/highlight.py", line 595, in _patterns
    tmp_regs, tmp_rules = self._include(
  File "/tmp/babi-grammars/venv/lib/python3.8/site-packages/babi/highlight.py", line 576, in _include
    return self._patterns(grammar, (repository[s[1:]],))
  File "/tmp/babi-grammars/venv/lib/python3.8/site-packages/babi/fdict.py", line 44, in __getitem__
    raise KeyError(key)
KeyError: 'discouraged-string-line-continuation'
```