### PR TITLE
[starlark] fix copy-to-label for root build file

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ run it.
 
 ## Advanced Features:
 
-The advanced features are available with a [Bzl](https://build.bzl.io)
+The advanced features are available with a [Bzl](https://bzl.io)
 subscription.  Sign-up on the website or within the vscode extension.  Read more
 about advanced features on the [documentation
 site](https://stackb.github.io/bazel-stack-vscode/).

--- a/docs/0_index.md
+++ b/docs/0_index.md
@@ -21,7 +21,7 @@ Boost Developer Productivity with Bazel Support for Visual Studio Code.
 
 ![ScreenFlow](https://user-images.githubusercontent.com/50580/95278334-37481500-080d-11eb-8931-88905c1c3d51.gif)
 
-This extension integrates with the [Bzl](https://build.bzl.io) tool.  Bzl is a
+This extension integrates with the [Bzl](https://bzl.io) tool.  Bzl is a
 web-based Bazel UI that runs as a subprocess of the extension:
 
 ![](https://user-images.githubusercontent.com/50580/93263024-644f5d80-f762-11ea-936d-aeed0c5788a9.gif)

--- a/docs/subscribing.md
+++ b/docs/subscribing.md
@@ -44,7 +44,7 @@ command from the palette or click the *Rocket* icon from the account view:
 ![get-started](https://user-images.githubusercontent.com/50580/95288941-d88f9500-0826-11eb-8d2e-b981ad2f2cab.gif)
 
 To view your account details or manage your subscription, proceed to
-<https://build.bzl.io/bzl/user>.
+<https://bzl.io/bzl/user>.
 
 ### Telemetry.
 

--- a/package.json
+++ b/package.json
@@ -54,22 +54,22 @@
         "onCommand:bsv.bzl.server.explore",
         "onCommand:bsv.bzl.server.refresh",
         "onCommand:bsv.bzl.server.restart",
-        "onCommand:bsv.bzl.server.shutdown",
         "onCommand:bsv.bzl.server.select",
+        "onCommand:bsv.bzl.server.shutdown",
         "onCommand:bsv.bzl.signup.start",
         "onCommand:bsv.bzl.workspace.explore",
         "onCommand:bsv.bzl.workspace.openTerminal",
         "onCommand:bsv.bzl.workspace.refresh",
         "onCommand:bsv.bzl.workspace.select",
+        "onCommand:bsv.openExtensionSetting",
         "onCommand:bzv.bzl.codesearch.index",
         "onCommand:bzv.bzl.codesearch.search",
-        "onCommand:bsv.openExtensionSetting",
         "onCommand:workbench.view.extension.bazel-explorer",
         "onCommand:workbench.view.extension.stackb-explorer",
-        "onCommand:bsv.starlark.lsp.copyLabel",
         "onLanguage:bazel",
         "onLanguage:bazelrc",
         "onLanguage:starlark",
+        "onView:bazel-explorer",
         "onView:bsv.bzl.account",
         "onView:bsv.bzl.bep",
         "onView:bsv.bzl.history",
@@ -77,7 +77,6 @@
         "onView:bsv.bzl.repository",
         "onView:bsv.bzl.server",
         "onView:bsv.bzl.workspace",
-        "onView:bazel-explorer",
         "onView:stackb-explorer"
     ],
     "engines": {
@@ -98,7 +97,7 @@
                     "default": 0,
                     "description": "The verbosity level for extra diagnostics"
                 },
-                "bsv.starlark.lsp.server.executable": {
+                "bsv.starlark.lsp.executable": {
                     "type": "string",
                     "description": "Path to a pre-installed LSP executable\n\n> if set, this prevents downloading a LSP binary from github"
                 },
@@ -117,7 +116,7 @@
                     "default": "0.9.7-rc1",
                     "description": "The github release tag of the starlark-lsp release to download"
                 },
-                "bsv.starlark.lsp.server.command": {
+                "bsv.starlark.lsp.command": {
                     "type": "array",
                     "description": "The command (and optional arguments) to start the lsp server.",
                     "items": {
@@ -160,7 +159,7 @@
                 },
                 "bsv.bzl.oauth.github.relay": {
                     "type": "string",
-                    "default": "https://build.bzl.io/github_login",
+                    "default": "https://bzl.io/github_login",
                     "description": "Endpoint for github oauth relay server"
                 },
                 "bsv.bzl.server.executable": {

--- a/package.json
+++ b/package.json
@@ -113,7 +113,7 @@
                 },
                 "bsv.starlark.lsp.github-release": {
                     "type": "string",
-                    "default": "0.9.7-rc1",
+                    "default": "0.9.11",
                     "description": "The github release tag of the starlark-lsp release to download"
                 },
                 "bsv.starlark.lsp.command": {
@@ -198,7 +198,7 @@
                 },
                 "bsv.bzl.server.github-release": {
                     "type": "string",
-                    "default": "0.9.6",
+                    "default": "0.9.11",
                     "description": "The github release tag of the bzl release to download"
                 },
                 "bsv.bzl.server.command": {

--- a/src/bzl/configuration.ts
+++ b/src/bzl/configuration.ts
@@ -124,7 +124,7 @@ export async function createBzlConfiguration(
         token: config.get<string>(ConfigSection.LicenseToken,
             ''),
         githubOAuthRelayUrl: config.get<string>(ConfigSection.OAuthGithubRelay,
-            'https://build.bzl.io/github_login'),
+            'https://bzl.io/github_login'),
     };
 
     const auth = {

--- a/src/bzl/configuration.ts
+++ b/src/bzl/configuration.ts
@@ -175,10 +175,8 @@ export async function createBzlConfiguration(
     const commandTask: CommandTaskConfiguration = {
         buildEventStreamProtofile: config.get<string>(ConfigSection.BuildEventStreamProto,
             asAbsolutePath('./proto/build_event_stream.proto')),
-        bazelExecutable: config.get<string>(ConfigSection.BazelExecutable,
-            asAbsolutePath('./proto/build_event_stream.proto')),
-        bazelVersion: config.get<string>(ConfigSection.BazelVersion,
-            asAbsolutePath('./proto/build_event_stream.proto')),
+        bazelExecutable: config.get<string>(ConfigSection.BazelExecutable, 'bazel'),
+        bazelVersion: config.get<string>(ConfigSection.BazelVersion, ''),
     };
 
     const cfg: BzlConfiguration = {

--- a/src/bzl/constants.ts
+++ b/src/bzl/constants.ts
@@ -176,5 +176,5 @@ export enum ContextValue {
 }
 
 export function ruleClassIconUri(ruleClass: string): vscode.Uri {
-    return vscode.Uri.parse(`https://results.bzl.io/v1/image/rule/${ruleClass}.svg`);
+    return vscode.Uri.parse(`https://bzl.io/v1/image/rule/${ruleClass}.svg`);
 }

--- a/src/bzl/view/signup.ts
+++ b/src/bzl/view/signup.ts
@@ -199,8 +199,8 @@ export class BzlGetStarted implements vscode.Disposable {
 	}
 
 	protected addCommand(name: string, command: (...args: any) => any) {
-        this.disposables.push(vscode.commands.registerCommand(name, command, this));
-    }
+		this.disposables.push(vscode.commands.registerCommand(name, command, this));
+	}
 
 	async handleCommandSignupStart(): Promise<void> {
 		if (!this.hasLicenseFile()) {
@@ -247,7 +247,7 @@ export class BzlGetStarted implements vscode.Disposable {
 			tabs: getTabs(['get-started', this.selectedAuthMethod || 'github-auth', 'select-plan', 'payment', 'confirm']),
 			activeTab: 'get-started',
 			heading: '',
-			subheading: '<a href="https://build.bzl.io" style="color: var(--vscode-editor-foreground)">Boost Productivity</a>',
+			subheading: '<a href="https://bzl.io" style="color: var(--vscode-editor-foreground)">Boost Productivity</a>',
 			image: {
 				url: 'https://user-images.githubusercontent.com/50580/95278334-37481500-080d-11eb-8931-88905c1c3d51.gif',
 			},
@@ -342,7 +342,7 @@ export class BzlGetStarted implements vscode.Disposable {
 						{ text: 'Test Results: show failed output in editor', },
 						{ text: 'Upload/share build event stream to https://results.bzl.io', },
 					],
-				},				
+				},
 				{
 					heading: 'Bzl Integration',
 					text: 'Dive deeper into the bazel graph and build event protocol.',
@@ -354,7 +354,7 @@ export class BzlGetStarted implements vscode.Disposable {
 						{ text: 'Build event stream invocation list', },
 						{ text: 'Codesearch', },
 						{ text: 'More...', },
-					],					
+					],
 				},
 				{
 					heading: 'Bzl Server Explorer',
@@ -365,7 +365,7 @@ export class BzlGetStarted implements vscode.Disposable {
 						{ text: 'Build Version Metadata', },
 						{ text: '--bes_backend flags', },
 						{ text: 'Connect to remote Bzl server', },
-					],					
+					],
 				},
 				{
 					heading: 'Stack.Build Explorer',
@@ -374,7 +374,7 @@ export class BzlGetStarted implements vscode.Disposable {
 					highlights: [
 						{ text: 'Launch the sign-up webview', },
 						{ text: 'Show account details', },
-					],					
+					],
 				},
 				{
 					heading: 'Sign-up Tool',
@@ -387,7 +387,7 @@ export class BzlGetStarted implements vscode.Disposable {
 						{ text: 'Payment details form', },
 						{ text: 'Payment confirmation form', },
 						{ text: 'Looks great with any vscode theme :)', },
-					],					
+					],
 				},
 			],
 		});
@@ -451,7 +451,7 @@ export class BzlGetStarted implements vscode.Disposable {
 		});
 
 		const flow = new RenewLicenseFlow(
-			this.licensesClient, 
+			this.licensesClient,
 			jwt,
 			() => this.tryListPlans(jwt),
 			() => this.tryListPlans(jwt),
@@ -1069,7 +1069,7 @@ export class BzlGetStarted implements vscode.Disposable {
 			subheading: 'Manual Configuration',
 			lead: `
 			<p>
-				Already <a href="https://build.bzl.io/bzl">signed up</a>?  Copy the value in the text file <code>~/.bzl/license.key</code> into your extension settings.
+				Already <a href="https://bzl.io/bzl">signed up</a>?  Copy the value in the text file <code>~/.bzl/license.key</code> into your extension settings.
 			</p>
 			`,
 			buttons: [

--- a/src/bzl/view/signup.ts
+++ b/src/bzl/view/signup.ts
@@ -340,7 +340,7 @@ export class BzlGetStarted implements vscode.Disposable {
 						{ text: 'Completed Target: reveal file in finder', },
 						{ text: 'Completed Target: save file to local filesystem (useful when connected to a remote Bzl instance)', },
 						{ text: 'Test Results: show failed output in editor', },
-						{ text: 'Upload/share build event stream to https://results.bzl.io', },
+						{ text: 'Upload/share build event stream to https://bzl.io', },
 					],
 				},
 				{

--- a/src/test/integration/feature.bzl.signup.test.ts
+++ b/src/test/integration/feature.bzl.signup.test.ts
@@ -18,7 +18,7 @@ describe(BzlFeatureName + '.signup', function () {
 	describe('GitHubOAuthFlow', () => {
 
 		it('Should timeout if no callback uri provided', async () => {
-			const flow = new GitHubOAuthFlow('https://build.bzl.io/github_login');
+			const flow = new GitHubOAuthFlow('https://bzl.io/github_login');
 			const state = 'abc123';
 			const promise = flow.login(state, 0.1, /* open external url */ false);
 			try {
@@ -32,7 +32,7 @@ describe(BzlFeatureName + '.signup', function () {
 
 		it('Should retrieve jwt from the callback uri', async () => {
 			const uriHandler = new UriEventHandler();
-			const flow = new GitHubOAuthFlow('https://build.bzl.io/github_login', uriHandler);
+			const flow = new GitHubOAuthFlow('https://bzl.io/github_login', uriHandler);
 			const state = 'abc123';
 			const expectedJwt = '12345';
 			const promise = flow.login(state, 30, /* open external url */ false);


### PR DESCRIPTION
Updates lsp binary to 0.9.11.
Also updates bzl.io hostname to the new shortened one.

Fixes #49 