### PR TITLE
Improve component status change logic

### DIFF
--- a/src/bezel/bazel.ts
+++ b/src/bezel/bazel.ts
@@ -19,20 +19,13 @@ export class BazelServer extends LaunchableComponent<BazelConfiguration> {
   }
 
   async startInternal(): Promise<void> {
-    try {
-      this.setStatus(Status.STARTING);
-      this.workspaceUri = await findWorkspaceFile(this.workspaceFolder.fsPath);
-      if (!this.workspaceUri) {
-        throw new Error(`WORKSPACE file not found`);
-      }
-      this.setStatus(Status.READY);
-    } catch (e) {
-      this.setError(e);
+    this.workspaceUri = await findWorkspaceFile(this.workspaceFolder.fsPath);
+    if (!this.workspaceUri) {
+      throw new Error(`WORKSPACE file not found`);
     }
   }
 
   async stopInternal(): Promise<void> {
-    this.setStatus(Status.STOPPED);
   }
 
   async getBazelInfo(): Promise<BazelInfo | undefined> {

--- a/src/bezel/bazel.ts
+++ b/src/bezel/bazel.ts
@@ -18,14 +18,15 @@ export class BazelServer extends LaunchableComponent<BazelConfiguration> {
     super('BAZ', settings, CommandName.LaunchBazelServer, 'bazel');
   }
 
-  async startInternal(): Promise<void> {
+  async shouldLaunch(e: Error): Promise<boolean> {
+    return false;
+  }
+
+  async launchInternal(): Promise<void> {
     this.workspaceUri = await findWorkspaceFile(this.workspaceFolder.fsPath);
     if (!this.workspaceUri) {
       throw new Error(`WORKSPACE file not found`);
     }
-  }
-
-  async stopInternal(): Promise<void> {
   }
 
   async getBazelInfo(): Promise<BazelInfo | undefined> {

--- a/src/bezel/bes.ts
+++ b/src/bezel/bes.ts
@@ -102,8 +102,7 @@ export class BuildEventService extends RunnableComponent<BuildEventServiceConfig
     });
   }
 
-  async stopInternal(): Promise<void> {
-  }
+  async stopInternal(): Promise<void> {}
 
   private handleGrpcError(err: grpc.ServiceError) {
     if (this.status !== Status.READY) {

--- a/src/bezel/bes.ts
+++ b/src/bezel/bes.ts
@@ -89,10 +89,6 @@ export class BuildEventService extends RunnableComponent<BuildEventServiceConfig
       case Status.DISABLED:
         this.setDisabled(true);
         break;
-      // If launching, follow that.
-      case Status.LAUNCHING:
-        this.setStatus(status);
-        break;
       // if ready, show ready also (kindof a hack)
       case Status.READY:
         this.setStatus(status);

--- a/src/bezel/bzl.ts
+++ b/src/bezel/bzl.ts
@@ -482,7 +482,7 @@ export class Bzl extends LaunchableComponent<BzlConfiguration> {
 
     return new Promise((resolve, reject) => {
       this.client = new BzlAPIClient(cfg, err => reject(err));
-      this.client.getMetadata().then(() => resolve(), reject);  
+      this.client.getMetadata().then(() => resolve(), reject);
     });
   }
 

--- a/src/bezel/bzl.ts
+++ b/src/bezel/bzl.ts
@@ -436,13 +436,7 @@ export class Bzl extends LaunchableComponent<BzlConfiguration> {
   }
 
   protected async handleSubscriptionStatusChange(status: Status) {
-    if (status === Status.DISABLED) {
-      this.setDisabled(true);
-      return;
-    }
-    if (this.status === Status.DISABLED) {
-      this.setDisabled(false);
-    }
+    this.restart();
   }
 
   public async getWorkspace(): Promise<Workspace> {

--- a/src/bezel/codelens.ts
+++ b/src/bezel/codelens.ts
@@ -22,7 +22,7 @@ export class BazelCodelensProvider implements vscode.Disposable, vscode.CodeLens
     private bazel: BazelServer,
     private codesearch: CodeSearch,
     private bzl: Bzl,
-    private debug: StarlarkDebugger,
+    private debug: StarlarkDebugger
   ) {
     this.disposables.push(vscode.languages.registerCodeLensProvider('bazel', this));
   }
@@ -35,8 +35,10 @@ export class BazelCodelensProvider implements vscode.Disposable, vscode.CodeLens
     const enableCodelensBuild = cfg.enableCodelensBuild && this.bazel.status === Status.READY;
     const enableCodelensTest = cfg.enableCodelensTest && this.bazel.status === Status.READY;
     const enableCodelensRun = cfg.enableCodelensRun && this.bazel.status === Status.READY;
-    const enableCodelensStarlarkDebug = cfg.enableCodelensStarlarkDebug && this.debug.status === Status.READY;
-    const enableCodelensCodesearch = cfg.enableCodelensCodesearch && this.codesearch.status === Status.READY;
+    const enableCodelensStarlarkDebug =
+      cfg.enableCodelensStarlarkDebug && this.debug.status === Status.READY;
+    const enableCodelensCodesearch =
+      cfg.enableCodelensCodesearch && this.codesearch.status === Status.READY;
     const enableCodelensBrowse = cfg.enableCodelensBrowse && this.bzl.status === Status.READY;
 
     try {
@@ -83,15 +85,22 @@ export class BazelCodelensProvider implements vscode.Disposable, vscode.CodeLens
       );
 
       const special = flatten([recursive, all]);
-      const normal = flatten(labelKinds.map(lk => this.createCodeLensesForLabelKindRange({
-        enableCodelensCopyLabel: cfg.enableCodelensCopyLabel,
-        enableCodelensBuild: enableCodelensBuild,
-        enableCodelensTest: enableCodelensTest,
-        enableCodelensRun: enableCodelensRun,
-        enableCodelensStarlarkDebug: enableCodelensStarlarkDebug,
-        enableCodelensCodesearch: enableCodelensCodesearch,
-        enableCodelensBrowse: enableCodelensBrowse,
-      }, lk)));
+      const normal = flatten(
+        labelKinds.map(lk =>
+          this.createCodeLensesForLabelKindRange(
+            {
+              enableCodelensCopyLabel: cfg.enableCodelensCopyLabel,
+              enableCodelensBuild: enableCodelensBuild,
+              enableCodelensTest: enableCodelensTest,
+              enableCodelensRun: enableCodelensRun,
+              enableCodelensStarlarkDebug: enableCodelensStarlarkDebug,
+              enableCodelensCodesearch: enableCodelensCodesearch,
+              enableCodelensBrowse: enableCodelensBrowse,
+            },
+            lk
+          )
+        )
+      );
 
       return special.concat(normal);
     } catch (err) {

--- a/src/bezel/codesearch.ts
+++ b/src/bezel/codesearch.ts
@@ -107,11 +107,11 @@ export class CodeSearch
   }
 
   async startInternal() {
-    this.setStatus(this.bzl.status);
+    // this.setStatus(this.bzl.status);
   }
 
   async stopInternal() {
-    this.setStatus(this.bzl.status);
+    // this.setStatus(this.bzl.status);
   }
 
   async handleCommandCodesearch(label: string): Promise<void> {

--- a/src/bezel/codesearch.ts
+++ b/src/bezel/codesearch.ts
@@ -79,8 +79,7 @@ export class CodeSearch
     }
   }
 
-  async stopInternal() {
-  }
+  async stopInternal() {}
 
   async handleCommandCodesearch(label: string): Promise<void> {
     const ws = await this.bzl.getWorkspace();

--- a/src/bezel/codesearch.ts
+++ b/src/bezel/codesearch.ts
@@ -89,10 +89,6 @@ export class CodeSearch
       case Status.DISABLED:
         this.setDisabled(true);
         break;
-      // If launching, follow that.
-      case Status.LAUNCHING:
-        this.setStatus(status);
-        break;
       // if ready, show ready also (kindof a hack)
       case Status.READY:
         this.setStatus(status);

--- a/src/bezel/codesearch.ts
+++ b/src/bezel/codesearch.ts
@@ -49,7 +49,7 @@ export class CodeSearch
   constructor(settings: CodeSearchSettings, public readonly bzl: Bzl) {
     super('CS0', settings);
 
-    bzl.onDidChangeStatus(this.handleBzlChangeStatus, this, this.disposables);
+    bzl.onDidChangeStatus(this.restart, this, this.disposables);
 
     this.output = vscode.window.createOutputChannel('Codesearch');
     this.renderer = new CodesearchRenderer();
@@ -73,41 +73,13 @@ export class CodeSearch
     );
   }
 
-  async handleBzlChangeStatus(status: Status) {
-    const cfg = await this.settings.get();
-    if (!cfg.enabled) {
-      return;
-    }
-
-    // If we are disabled, re-reenable if any other bzl status.
-    if (this.status === Status.DISABLED && status !== Status.DISABLED) {
-      this.setDisabled(false);
-    }
-
-    switch (status) {
-      // Disable if upstream is disabled
-      case Status.DISABLED:
-        this.setDisabled(true);
-        break;
-      // if ready, show ready also (kindof a hack)
-      case Status.READY:
-        this.setStatus(status);
-        break;
-      case Status.ERROR:
-        this.setError(new Error(this.bzl.statusErrorMessage));
-        break;
-      default:
-        this.restart();
-        break;
-    }
-  }
-
   async startInternal() {
-    // this.setStatus(this.bzl.status);
+    if (this.bzl.status !== Status.READY) {
+      throw new Error(`Bzl Service not ready`);
+    }
   }
 
   async stopInternal() {
-    // this.setStatus(this.bzl.status);
   }
 
   async handleCommandCodesearch(label: string): Promise<void> {

--- a/src/bezel/configuration.ts
+++ b/src/bezel/configuration.ts
@@ -11,7 +11,7 @@ import { getGRPCCredentials, loadBzlProtos, loadCodesearchProtos } from './proto
 import { Container } from '../container';
 
 /**
- * Configuration for the bzl server.
+ * Configuration for a generic component.
  */
 export interface ComponentConfiguration {
   // Boolean flag indicating if the component is enabled

--- a/src/bezel/debugger.ts
+++ b/src/bezel/debugger.ts
@@ -26,8 +26,7 @@ export class StarlarkDebugger
     return false;
   }
 
-  async launchInternal(): Promise<void> {
-  }
+  async launchInternal(): Promise<void> {}
 
   async invoke(command: string, label: string): Promise<void> {
     const bazel = await this.bazelSettings.get();

--- a/src/bezel/debugger.ts
+++ b/src/bezel/debugger.ts
@@ -23,12 +23,9 @@ export class StarlarkDebugger
   }
 
   async startInternal(): Promise<void> {
-    this.setStatus(Status.STARTING);
-    this.setStatus(Status.READY);
   }
 
   async stopInternal(): Promise<void> {
-    this.setStatus(Status.STOPPED);
   }
 
   async invoke(command: string, label: string): Promise<void> {

--- a/src/bezel/debugger.ts
+++ b/src/bezel/debugger.ts
@@ -22,10 +22,11 @@ export class StarlarkDebugger
     super('SDB', settings, CommandName.LaunchDebugCLI, 'debug-cli');
   }
 
-  async startInternal(): Promise<void> {
+  async shouldLaunch(e: Error): Promise<boolean> {
+    return false;
   }
 
-  async stopInternal(): Promise<void> {
+  async launchInternal(): Promise<void> {
   }
 
   async invoke(command: string, label: string): Promise<void> {

--- a/src/bezel/feature.ts
+++ b/src/bezel/feature.ts
@@ -142,13 +142,9 @@ export class BzlFeature implements vscode.Disposable {
       new Invocations(invocationsSettings, lspClient, bzl, this.api)
     );
 
-    this.addDisposable(new BazelCodelensProvider(
-      lspClient,
-      bazelServer,
-      codeSearch,
-      bzl,
-      starlarkDebugger,
-    ));
+    this.addDisposable(
+      new BazelCodelensProvider(lspClient, bazelServer, codeSearch, bzl, starlarkDebugger)
+    );
 
     this.addDisposable(
       new BezelWorkspaceView(

--- a/src/bezel/invocations.ts
+++ b/src/bezel/invocations.ts
@@ -60,46 +60,18 @@ export class Invocations extends RunnableComponent<InvocationsConfiguration> {
     public readonly problemMatcherRegistry: problemMatcher.IProblemMatcherRegistry
   ) {
     super('INV', settings);
-    bzl.onDidChangeStatus(this.handleBzlChangeStatus, this, this.disposables);
+    bzl.onDidChangeStatus(this.restart, this, this.disposables);
 
     this.addCommand(CommandName.InvocationInvoke, this.handleCommandInvocationInvoke);
   }
 
-  async handleBzlChangeStatus(status: Status) {
-    const cfg = await this.settings.get();
-    if (!cfg.enabled) {
-      return;
-    }
-
-    // If we are disabled, re-reenable if any other bzl status.
-    if (this.status === Status.DISABLED && status !== Status.DISABLED) {
-      this.setDisabled(false);
-    }
-
-    switch (status) {
-      // Disable if upstream is disabled
-      case Status.DISABLED:
-        this.setDisabled(true);
-        break;
-      // if ready, show ready also (kindof a hack)
-      case Status.READY:
-        this.setStatus(status);
-        break;
-      case Status.ERROR:
-        this.setError(new Error(this.bzl.statusErrorMessage));
-        break;
-      default:
-        this.restart();
-        break;
-    }
-  }
-
   async startInternal() {
-    // this.setStatus(this.bzl.status);
+    if (this.bzl.status !== Status.READY) {
+      throw new Error(`Bzl Service not ready`);
+    }
   }
 
   async stopInternal() {
-    // this.setStatus(this.bzl.status);
   }
 
   async handleCommandInvocationInvoke(item: InvocationItem): Promise<void> {

--- a/src/bezel/invocations.ts
+++ b/src/bezel/invocations.ts
@@ -81,10 +81,6 @@ export class Invocations extends RunnableComponent<InvocationsConfiguration> {
       case Status.DISABLED:
         this.setDisabled(true);
         break;
-      // If launching, follow that.
-      case Status.LAUNCHING:
-        this.setStatus(status);
-        break;
       // if ready, show ready also (kindof a hack)
       case Status.READY:
         this.setStatus(status);

--- a/src/bezel/invocations.ts
+++ b/src/bezel/invocations.ts
@@ -99,11 +99,11 @@ export class Invocations extends RunnableComponent<InvocationsConfiguration> {
   }
 
   async startInternal() {
-    this.setStatus(this.bzl.status);
+    // this.setStatus(this.bzl.status);
   }
 
   async stopInternal() {
-    this.setStatus(this.bzl.status);
+    // this.setStatus(this.bzl.status);
   }
 
   async handleCommandInvocationInvoke(item: InvocationItem): Promise<void> {

--- a/src/bezel/invocations.ts
+++ b/src/bezel/invocations.ts
@@ -71,8 +71,7 @@ export class Invocations extends RunnableComponent<InvocationsConfiguration> {
     }
   }
 
-  async stopInternal() {
-  }
+  async stopInternal() {}
 
   async handleCommandInvocationInvoke(item: InvocationItem): Promise<void> {
     let args = [item.inv.command];

--- a/src/bezel/lsp.ts
+++ b/src/bezel/lsp.ts
@@ -40,31 +40,28 @@ export class BzlLanguageClient
   }
 
   async startInternal(): Promise<void> {
-    if (this.languageClient) {
-      return;
-    }
-    if (this.status === Status.STARTING) {
-      return;
-    }
-    this.setStatus(Status.STARTING);
+    // if (this.languageClient) {
+    //   return;
+    // }
+    // if (this.status === Status.STARTING) {
+    //   return;
+    // }
+    // this.setStatus(Status.STARTING);
 
-    try {
-      const cfg = await this.settings.get();
-      const client = (this.languageClient = createLanguageClient(cfg));
-      client.onDidChangeState(this.handleStateChangeEvent, this, this.clientDisposables);
+    const cfg = await this.settings.get();
+    if (!this.languageClient) {
+      this.languageClient = createLanguageClient(cfg);
+      this.languageClient.onDidChangeState(this.handleStateChangeEvent, this, this.clientDisposables);
       this.clientDisposables.push(this.languageClient.start());
-      await this.languageClient.onReady();
-    } catch (e) {
-      this.setError(e);
     }
+
+    await this.languageClient.onReady();
   }
 
   async stopInternal(): Promise<void> {
     try {
       await this.languageClient?.stop();
       this.languageClient = undefined;
-    } catch (e) {
-      this.setError(e);
     } finally {
       this.disposeClient();
     }

--- a/src/bezel/lsp.ts
+++ b/src/bezel/lsp.ts
@@ -40,18 +40,14 @@ export class BzlLanguageClient
   }
 
   async startInternal(): Promise<void> {
-    // if (this.languageClient) {
-    //   return;
-    // }
-    // if (this.status === Status.STARTING) {
-    //   return;
-    // }
-    // this.setStatus(Status.STARTING);
-
     const cfg = await this.settings.get();
     if (!this.languageClient) {
       this.languageClient = createLanguageClient(cfg);
-      this.languageClient.onDidChangeState(this.handleStateChangeEvent, this, this.clientDisposables);
+      this.languageClient.onDidChangeState(
+        this.handleStateChangeEvent,
+        this,
+        this.clientDisposables
+      );
       this.clientDisposables.push(this.languageClient.start());
     }
 

--- a/src/bezel/remote_cache.ts
+++ b/src/bezel/remote_cache.ts
@@ -103,15 +103,4 @@ export class RemoteCache extends LaunchableComponent<RemoteCacheConfiguration> {
       client.getServerCapabilities().then(() => resolve(), reject);
     });
   }
-
-  // private handleGrpcError(err: grpc.ServiceError) {
-  //   if (this.status !== Status.READY) {
-  //     return;
-  //   }
-  //   switch (err.code) {
-  //     case grpc.status.UNAVAILABLE:
-  //       this.restart();
-  //       break;
-  //   }
-  // }
 }

--- a/src/bezel/remote_cache.ts
+++ b/src/bezel/remote_cache.ts
@@ -87,7 +87,16 @@ export class RemoteCache extends LaunchableComponent<RemoteCacheConfiguration> {
     return { command: args };
   }
 
-  async startInternal(): Promise<void> {
+  async shouldLaunch(e: Error): Promise<boolean> {
+    const grpcError: grpc.ServiceError = e as grpc.ServiceError;
+    if (grpcError.code === grpc.status.UNAVAILABLE) {
+      const cfg = await this.settings.get();
+      return cfg.autoLaunch;
+    }
+    return false;
+  }
+
+  async launchInternal(): Promise<void> {
     const cfg = await this.settings.get();
     const creds = getGRPCCredentials(cfg.address.authority);
 
@@ -100,27 +109,6 @@ export class RemoteCache extends LaunchableComponent<RemoteCacheConfiguration> {
          );
       client.getServerCapabilities().then(() => resolve(), reject);
     });
-    // try {
-    //   console.info('remote cache starting!');
-    //   const creds = getGRPCCredentials(cfg.address.authority);
-    //   const client = ();
-    //   await client.getServerCapabilities();
-    //   this.setStatus(Status.READY);
-    // } catch (e) {
-    //   const grpcError: grpc.ServiceError = e as grpc.ServiceError;
-    //   if (grpcError.code === grpc.status.UNAVAILABLE) {
-    //     if (cfg.autoLaunch) {
-    //       this.handleCommandLaunch();
-    //     } else {
-    //       this.setError(new Error('Launch the Remote Cache process (autoLaunch is false)'));
-    //     }
-    //   } else {
-    //     this.setError(e);
-    //   }
-    // }
-  }
-
-  async stopInternal(): Promise<void> {
   }
 
   // private handleGrpcError(err: grpc.ServiceError) {

--- a/src/bezel/remote_cache.ts
+++ b/src/bezel/remote_cache.ts
@@ -8,9 +8,8 @@ import { ProtoGrpcType as RemoteExecutionProtoType } from '../proto/remote_execu
 import { RemoteCacheConfiguration, RemoteCacheSettings } from './configuration';
 import { GRPCClient } from './grpcclient';
 import { getGRPCCredentials } from './proto';
-import { LaunchableComponent, LaunchArgs, Status } from './status';
+import { LaunchableComponent, LaunchArgs } from './status';
 import { CommandName } from './constants';
-import { rejects } from 'assert';
 
 function loadRemoteExecutionProtos(protofile: string): RemoteExecutionProtoType {
   const protoPackage = loader.loadSync(protofile, {
@@ -62,7 +61,6 @@ class RemoteCacheClient extends GRPCClient {
 }
 
 export class RemoteCache extends LaunchableComponent<RemoteCacheConfiguration> {
-
   constructor(
     public readonly settings: RemoteCacheSettings,
     private readonly proto = loadRemoteExecutionProtos(
@@ -101,12 +99,7 @@ export class RemoteCache extends LaunchableComponent<RemoteCacheConfiguration> {
     const creds = getGRPCCredentials(cfg.address.authority);
 
     return new Promise((resolve, reject) => {
-      const client = new RemoteCacheClient(
-           cfg.address,
-           creds,
-           this.proto,
-           err => reject(err),
-         );
+      const client = new RemoteCacheClient(cfg.address, creds, this.proto, err => reject(err));
       client.getServerCapabilities().then(() => resolve(), reject);
     });
   }

--- a/src/bezel/settings.ts
+++ b/src/bezel/settings.ts
@@ -69,7 +69,7 @@ export abstract class Settings<T extends ComponentConfiguration>
       this.cfg = Promise.resolve(cfg);
       this._onDidConfigurationChange.fire(cfg);
     } catch (e) {
-      this.cfg = Promise.reject(`could not configure "${section}": ${e.message}`)
+      this.cfg = Promise.reject(e);
       this._onDidConfigurationError.fire(e);
     }
 

--- a/src/bezel/settings.ts
+++ b/src/bezel/settings.ts
@@ -1,5 +1,4 @@
 import * as vscode from 'vscode';
-import { BuiltInCommands } from '../constants';
 import { Container } from '../container';
 import { ComponentConfiguration } from './configuration';
 
@@ -29,40 +28,21 @@ function getConfigurationProperties(prefix: string): Map<string, ConfigurationPr
 }
 
 export abstract class Settings<T extends ComponentConfiguration>
-  extends vscode.TreeItem
   implements vscode.Disposable
 {
   protected disposables: vscode.Disposable[] = [];
   private cfg: Promise<T> | undefined;
-  private props: Map<string, ConfigurationProperty>;
+  public readonly props: Map<string, ConfigurationProperty>;
   private _onDidConfigurationChange: vscode.EventEmitter<T> = new vscode.EventEmitter();
   public onDidConfigurationChange: vscode.Event<T> = this._onDidConfigurationChange.event;
   private _onDidConfigurationError: vscode.EventEmitter<Error> = new vscode.EventEmitter();
   public onDidConfigurationError: vscode.Event<Error> = this._onDidConfigurationError.event;
 
   constructor(public readonly section: string) {
-    super('Settings');
     this.props = getConfigurationProperties(section);
-    this.description = section;
-    this.iconPath = new vscode.ThemeIcon('gear');
-    this.tooltip = new vscode.MarkdownString(
-      `### Settings for "${section}"
-      
-      Click to open the VSCode settings and update the configuration items as desired.
-
-      Changes should be reflected automatically, you should not need to reload the window.
-      `
-    );
-    this.collapsibleState = vscode.TreeItemCollapsibleState.Collapsed;
-    this.command = {
-      title: 'Edit settings',
-      command: BuiltInCommands.OpenSettings,
-      arguments: [section],
-    };
 
     this.disposables.push(this._onDidConfigurationChange);
     this.disposables.push(this._onDidConfigurationError);
-
     this.disposables.push(
       vscode.workspace.onDidChangeConfiguration(async e => {
         if (e.affectsConfiguration(section)) {
@@ -77,7 +57,7 @@ export abstract class Settings<T extends ComponentConfiguration>
     try {
       const config = vscode.workspace.getConfiguration(section);
       if (!config) {
-        throw new Error(`error: configuration section "${section}" not found.`);
+        throw new Error(`configuration section "${section}" not found.`);
       }
       const cfg = await this.configure(config);
 
@@ -88,16 +68,12 @@ export abstract class Settings<T extends ComponentConfiguration>
 
       this.cfg = Promise.resolve(cfg);
       this._onDidConfigurationChange.fire(cfg);
-      return this.cfg;
     } catch (e) {
-      this.iconPath = new vscode.ThemeIcon('warning');
-      this.collapsibleState = vscode.TreeItemCollapsibleState.None;
-
-      const msg = `could not configure "${section}": ${e.message}`;
+      this.cfg = Promise.reject(`could not configure "${section}": ${e.message}`)
       this._onDidConfigurationError.fire(e);
-      this.description = e.message;
-      return (this.cfg = Promise.reject(msg));
     }
+
+    return this.cfg;
   }
 
   protected abstract configure(config: vscode.WorkspaceConfiguration): Promise<T>;
@@ -107,21 +83,6 @@ export abstract class Settings<T extends ComponentConfiguration>
       this.cfg = this.reconfigure(this.section);
     }
     return this.cfg;
-  }
-
-  async getChildren(): Promise<vscode.TreeItem[] | undefined> {
-    return Array.from(this.props.values()).map(p => {
-      const item = new vscode.TreeItem(p.name);
-      item.description = formatValue(p.value, p.default);
-      item.tooltip = p.description;
-      item.iconPath = new vscode.ThemeIcon(getThemeIconNameForPropertyType(p.type));
-      item.command = {
-        title: 'Edit Setting',
-        command: BuiltInCommands.OpenSettings,
-        arguments: [p.key],
-      };
-      return item;
-    });
   }
 
   dispose() {
@@ -137,29 +98,4 @@ interface ConfigurationProperty {
   description: string;
   type: string;
   default?: any;
-}
-
-function getThemeIconNameForPropertyType(type: string): string {
-  switch (type) {
-    case 'string':
-      return 'symbol-string';
-    case 'array':
-      return 'symbol-array';
-    case 'number':
-      return 'symbol-number';
-    case 'boolean':
-      return 'symbol-boolean';
-    default:
-      return 'symbol-property';
-  }
-}
-
-function formatValue(v: any, def?: any): string {
-  if (Array.isArray(v)) {
-    return v.join(' ');
-  }
-  if (typeof v === 'undefined') {
-    return '';
-  }
-  return String(v);
 }

--- a/src/bezel/settings.ts
+++ b/src/bezel/settings.ts
@@ -27,9 +27,7 @@ function getConfigurationProperties(prefix: string): Map<string, ConfigurationPr
   return matched;
 }
 
-export abstract class Settings<T extends ComponentConfiguration>
-  implements vscode.Disposable
-{
+export abstract class Settings<T extends ComponentConfiguration> implements vscode.Disposable {
   protected disposables: vscode.Disposable[] = [];
   private cfg: Promise<T> | undefined;
   public readonly props: Map<string, ConfigurationProperty>;

--- a/src/bezel/status.ts
+++ b/src/bezel/status.ts
@@ -13,7 +13,6 @@ export enum Status {
   READY = 'ready',
   STOPPING = 'stopping',
   STOPPED = 'stopped',
-  LAUNCHING = 'launching',
   FAILED = 'failed',
   ERROR = 'error',
 }
@@ -294,8 +293,6 @@ export abstract class LaunchableComponent<
     }
     terminal.sendText(command, true);
     terminal.show();
-
-    this.setStatus(Status.LAUNCHING);
 
     let iteration = this.launchIterations;
     const timeout = setInterval(() => {

--- a/src/bezel/status.ts
+++ b/src/bezel/status.ts
@@ -149,7 +149,7 @@ export interface LaunchArgs {
 
 export abstract class LaunchableComponent<
   T extends ComponentConfiguration
-  > extends RunnableComponent<T> {
+> extends RunnableComponent<T> {
   public terminal: vscode.Terminal | undefined;
 
   _onDidAttachTerminal: vscode.EventEmitter<vscode.Terminal> =

--- a/src/bezel/status.ts
+++ b/src/bezel/status.ts
@@ -116,7 +116,6 @@ export abstract class RunnableComponent<T extends ComponentConfiguration>
       this.setStatus(Status.READY);
     } catch (e) {
       this.setError(e);
-    } finally {
     }
   }
 
@@ -124,9 +123,10 @@ export abstract class RunnableComponent<T extends ComponentConfiguration>
     if (this._status === Status.DISABLED) {
       return;
     }
+    this.setStatus(Status.STOPPING);
     try {
       await this.stopInternal();
-      this.setStatus(Status.STOPPED)  
+      this.setStatus(Status.STOPPED);
     } catch (e) {
       this.setError(e);
     }

--- a/src/bezel/status.ts
+++ b/src/bezel/status.ts
@@ -8,7 +8,6 @@ export enum Status {
   UNKNOWN = 'unknown',
   DISABLED = 'disabled',
   INITIAL = 'initial',
-  CONFIGURING = 'configuring',
   STARTING = 'starting',
   READY = 'ready',
   STOPPING = 'stopping',

--- a/src/bezel/status.ts
+++ b/src/bezel/status.ts
@@ -50,13 +50,6 @@ export abstract class RunnableComponent<T extends ComponentConfiguration>
   }
 
   protected async handleConfigurationChanged(cfg: T) {
-    if (!cfg.enabled) {
-      this.setDisabled(true);
-      return;
-    }
-    if (this.status === Status.DISABLED && cfg.enabled) {
-      this.setDisabled(false);
-    }
     await this.restart();
   }
 
@@ -110,9 +103,6 @@ export abstract class RunnableComponent<T extends ComponentConfiguration>
   }
 
   async start(): Promise<void> {
-    if (this._status === Status.DISABLED) {
-      return;
-    }
     const cfg = await this.settings.get();
     if (!cfg.enabled) {
       this.setDisabled(true);

--- a/src/bezel/subscription.ts
+++ b/src/bezel/subscription.ts
@@ -122,6 +122,11 @@ export class Subscription extends RunnableComponent<SubscriptionConfiguration> {
     }
     const creds = getGRPCCredentials(cfg.serverAddress.authority);
     this.client = new AccountClient(cfg.serverAddress, creds, this.proto);
+    const license = await this.client.getLicense(cfg.token);
+    if (!license) {
+      throw new Error(`Subscription license unavailable`);
+    }
+    // TODO: check license expiration
   }
 
   async stopInternal(): Promise<void> {

--- a/src/bezel/subscription.ts
+++ b/src/bezel/subscription.ts
@@ -44,7 +44,7 @@ class AccountClient extends GRPCClient {
     );
   }
 
-  handleGrpcError(err: grpc.ServiceError) { }
+  handleGrpcError(err: grpc.ServiceError) {}
 
   async getLicense(token: string): Promise<License | undefined> {
     return new Promise<License>((resolve, reject) => {
@@ -129,6 +129,5 @@ export class Subscription extends RunnableComponent<SubscriptionConfiguration> {
     // TODO: check license expiration
   }
 
-  async stopInternal(): Promise<void> {
-  }
+  async stopInternal(): Promise<void> {}
 }

--- a/src/bezel/subscription.ts
+++ b/src/bezel/subscription.ts
@@ -44,7 +44,7 @@ class AccountClient extends GRPCClient {
     );
   }
 
-  handleGrpcError(err: grpc.ServiceError) {}
+  handleGrpcError(err: grpc.ServiceError) { }
 
   async getLicense(token: string): Promise<License | undefined> {
     return new Promise<License>((resolve, reject) => {
@@ -110,24 +110,20 @@ export class Subscription extends RunnableComponent<SubscriptionConfiguration> {
   }
 
   async startInternal(): Promise<void> {
+    if (this.client) {
+      this.client.dispose();
+    }
     // start calls settings such that we discover a configuration error upon
     // startup.
-    try {
-      const cfg = await this.settings.get();
-      if (!cfg.token) {
-        this.setDisabled(true);
-        return;
-      }
-      this.setStatus(Status.STARTING);
-      const creds = getGRPCCredentials(cfg.serverAddress.authority);
-      this.client = new AccountClient(cfg.serverAddress, creds, this.proto);
-      this.setStatus(Status.READY);
-    } catch (e) {
-      this.setError(e);
+    const cfg = await this.settings.get();
+    if (!cfg.token) {
+      this.setDisabled(true);
+      return;
     }
+    const creds = getGRPCCredentials(cfg.serverAddress.authority);
+    this.client = new AccountClient(cfg.serverAddress, creds, this.proto);
   }
 
   async stopInternal(): Promise<void> {
-    this.setStatus(Status.STOPPED);
   }
 }

--- a/src/bezel/workspaceView.ts
+++ b/src/bezel/workspaceView.ts
@@ -265,9 +265,6 @@ export abstract class RunnableComponentItem<T extends ComponentConfiguration>
       case Status.STOPPED:
         icon = 'close';
         break;
-      case Status.CONFIGURING:
-        icon = 'sync~spin';
-        break;
       case Status.READY:
         icon = 'testing-passed-icon';
         this.collapsibleState = vscode.TreeItemCollapsibleState.Collapsed;

--- a/src/bezel/workspaceView.ts
+++ b/src/bezel/workspaceView.ts
@@ -203,7 +203,8 @@ export class BezelWorkspaceView extends TreeView<vscode.TreeItem> {
 
 export abstract class RunnableComponentItem<T extends ComponentConfiguration>
   extends vscode.TreeItem
-  implements vscode.Disposable {
+  implements vscode.Disposable
+{
   disposables: vscode.Disposable[] = [];
   private previousStatus: Status = Status.UNKNOWN;
   private settings: SettingsItem;
@@ -221,7 +222,11 @@ export abstract class RunnableComponentItem<T extends ComponentConfiguration>
     this.contextValue = 'component';
     component.onDidChangeStatus(this.setStatus, this, this.disposables);
     this.setStatus(component.status);
-    this.settings = new SettingsItem(this.component.settings, onDidChangeTreeData, this.disposables);
+    this.settings = new SettingsItem(
+      this.component.settings,
+      onDidChangeTreeData,
+      this.disposables
+    );
   }
 
   async getChildren(): Promise<vscode.TreeItem[]> {
@@ -245,7 +250,7 @@ export abstract class RunnableComponentItem<T extends ComponentConfiguration>
     if (status === this.previousStatus) {
       return;
     }
-    
+
     this.description = this.initialDescription;
     let icon = 'question';
 
@@ -297,7 +302,7 @@ export class SettingsItem extends vscode.TreeItem {
   constructor(
     private readonly settings: Settings<ComponentConfiguration>,
     onDidChangeTreeData: (item: vscode.TreeItem) => void,
-    disposables: vscode.Disposable[],
+    disposables: vscode.Disposable[]
   ) {
     super('Settings');
     this.description = settings.section;
@@ -318,15 +323,27 @@ export class SettingsItem extends vscode.TreeItem {
       arguments: [settings.section],
     };
 
-    disposables.push(settings.onDidConfigurationChange(cfg => {
-      this.description = this.settings.section;
-      onDidChangeTreeData(this);
-    }, this, disposables));
+    disposables.push(
+      settings.onDidConfigurationChange(
+        cfg => {
+          this.description = this.settings.section;
+          onDidChangeTreeData(this);
+        },
+        this,
+        disposables
+      )
+    );
 
-    disposables.push(settings.onDidConfigurationError(e => {
-      this.description = e.message;
-      onDidChangeTreeData(this);
-    }, this, disposables));
+    disposables.push(
+      settings.onDidConfigurationError(
+        e => {
+          this.description = e.message;
+          onDidChangeTreeData(this);
+        },
+        this,
+        disposables
+      )
+    );
   }
 
   async getChildren(): Promise<vscode.TreeItem[] | undefined> {
@@ -345,10 +362,10 @@ export class SettingsItem extends vscode.TreeItem {
   }
 }
 
-
 class SubscriptionItem
   extends RunnableComponentItem<SubscriptionConfiguration>
-  implements Expandable {
+  implements Expandable
+{
   constructor(
     private subscription: Subscription,
     onDidChangeTreeData: (item: vscode.TreeItem) => void
@@ -434,7 +451,8 @@ class AccountLinkItem extends vscode.TreeItem {
 
 class StarlarkLanguageServerItem
   extends RunnableComponentItem<LanguageServerConfiguration>
-  implements Expandable {
+  implements Expandable
+{
   constructor(lspClient: BzlLanguageClient, onDidChangeTreeData: (item: vscode.TreeItem) => void) {
     super('Starlark', 'Language Server', lspClient, onDidChangeTreeData);
     this.iconPath = Container.media(MediaIconName.StackBuild);
@@ -448,7 +466,8 @@ class StarlarkLanguageServerItem
 
 class BuildifierItem
   extends RunnableComponentItem<BuildifierConfiguration>
-  implements vscode.Disposable, Expandable {
+  implements vscode.Disposable, Expandable
+{
   constructor(buildifier: Buildifier, onDidChangeTreeData: (item: vscode.TreeItem) => void) {
     super('Buildifier', 'Formatter', buildifier, onDidChangeTreeData);
     this.collapsibleState = vscode.TreeItemCollapsibleState.Collapsed;
@@ -461,7 +480,8 @@ class BuildifierItem
 
 class RemoteCacheItem
   extends RunnableComponentItem<RemoteCacheConfiguration>
-  implements vscode.Disposable, Expandable {
+  implements vscode.Disposable, Expandable
+{
   constructor(
     private remoteCache: RemoteCache,
     onDidChangeTreeData: (item: vscode.TreeItem) => void
@@ -510,7 +530,8 @@ class RemoteCacheItem
 
 class BzlServerItem
   extends RunnableComponentItem<BzlConfiguration>
-  implements vscode.Disposable, Expandable {
+  implements vscode.Disposable, Expandable
+{
   constructor(private bzl: Bzl, onDidChangeTreeData: (item: vscode.TreeItem) => void) {
     super('Bzl', 'Service', bzl, onDidChangeTreeData);
     this.collapsibleState = vscode.TreeItemCollapsibleState.Collapsed;
@@ -589,7 +610,8 @@ export class BzlFrontendLinkItem extends vscode.TreeItem {
 
 class BuildEventServiceItem
   extends RunnableComponentItem<BuildEventServiceConfiguration>
-  implements vscode.Disposable, Expandable {
+  implements vscode.Disposable, Expandable
+{
   constructor(
     private bes: BuildEventService,
     private bzlSettings: Settings<BzlConfiguration>,
@@ -628,7 +650,8 @@ class BuildEventServiceItem
 
 class StarlarkDebuggerItem
   extends RunnableComponentItem<StarlarkDebuggerConfiguration>
-  implements vscode.Disposable, Expandable {
+  implements vscode.Disposable, Expandable
+{
   constructor(
     private readonly debug: StarlarkDebugger,
     onDidChangeTreeData: (item: vscode.TreeItem) => void
@@ -734,7 +757,8 @@ be active to pause.  Repeat at step 3.
 
 class CodeSearchItem
   extends RunnableComponentItem<CodeSearchConfiguration>
-  implements vscode.Disposable, Expandable {
+  implements vscode.Disposable, Expandable
+{
   constructor(
     private codeSearch: CodeSearch,
     onDidChangeTreeData: (item: vscode.TreeItem) => void
@@ -767,7 +791,8 @@ class CodeSearchItem
 
 class BazelServerItem
   extends RunnableComponentItem<BazelConfiguration>
-  implements vscode.Disposable, Expandable {
+  implements vscode.Disposable, Expandable
+{
   constructor(private bazel: BazelServer, onDidChangeTreeData: (item: vscode.TreeItem) => void) {
     super('Bazel', 'Service', bazel, onDidChangeTreeData);
     this.collapsibleState = vscode.TreeItemCollapsibleState.Collapsed;
@@ -1038,7 +1063,6 @@ function infoMap(infoList: Info[]): Map<string, Info> {
   }
   return m;
 }
-
 
 function getThemeIconNameForPropertyType(type: string): string {
   switch (type) {

--- a/src/bezel/workspaceView.ts
+++ b/src/bezel/workspaceView.ts
@@ -37,7 +37,6 @@ import { Settings } from './settings';
 import { StarlarkDebugger } from './debugger';
 import { CodeSearch } from './codesearch';
 import { Invocations, InvocationsItem } from './invocations';
-import { timeStamp } from 'console';
 
 export interface Expandable {
   getChildren(): Promise<vscode.TreeItem[] | undefined>;

--- a/src/buildifier/buildifier.ts
+++ b/src/buildifier/buildifier.ts
@@ -18,6 +18,5 @@ export class Buildifier extends RunnableComponent<BuildifierConfiguration> {
     await this.settings.get();
   }
 
-  async stopInternal(): Promise<void> {
-  }
+  async stopInternal(): Promise<void> {}
 }

--- a/src/buildifier/buildifier.ts
+++ b/src/buildifier/buildifier.ts
@@ -15,15 +15,9 @@ export class Buildifier extends RunnableComponent<BuildifierConfiguration> {
   async startInternal(): Promise<void> {
     // start calls settings such that we discover a configuration error upon
     // startup.
-    try {
-      await this.settings.get();
-      this.setStatus(Status.READY);
-    } catch (e) {
-      this.setError(e);
-    }
+    await this.settings.get();
   }
 
   async stopInternal(): Promise<void> {
-    this.setStatus(Status.STOPPED);
   }
 }


### PR DESCRIPTION
The new logic around determining how component status changes affect the extension is a bit convoluted.  This PR simplifies it.