### PR TITLE
Feature: Jump to label

### DIFF
--- a/package.json
+++ b/package.json
@@ -482,6 +482,12 @@
             },
             {
                 "category": "Bzl",
+                "command": "bsv.bzl.goToLabel",
+                "title": "Bazel: Goto Label",
+                "icon": "$(go-to-file)"
+            },
+            {
+                "category": "Bzl",
                 "command": "bsv.buildozer.wizard",
                 "title": "Buildozer: Run Command Wizard",
                 "icon": "$(zap)"
@@ -577,6 +583,10 @@
             {
                 "command": "bsv.buildozer.wizard",
                 "key": "ctrl+shift+cmd+p"
+            },
+            {
+                "command": "bsv.bzl.goToLabel",
+                "key": "cmd+;"
             },
             {
                 "command": "workbench.view.extension.bazel-explorer",

--- a/src/bazeldoc/feature.ts
+++ b/src/bazeldoc/feature.ts
@@ -1,7 +1,7 @@
 import * as vscode from 'vscode';
 import { ConfigSection } from './constants';
 import { BazelDocConfiguration, builtInGroups } from './configuration';
-import { BazelDocGroupHover } from './hover';
+// import { BazelDocGroupHover } from './hover';
 import { Reconfigurable } from '../reconfigurable';
 
 export const BazelDocFeatureName = 'bsv.bazeldoc';
@@ -10,7 +10,7 @@ export class BazelDocFeature extends Reconfigurable<BazelDocConfiguration> {
   constructor() {
     super(BazelDocFeatureName);
 
-    this.add(new BazelDocGroupHover(this.onDidConfigurationChange.event));
+    //this.add(new BazelDocGroupHover(this.onDidConfigurationChange.event));
   }
 
   protected async configure(config: vscode.WorkspaceConfiguration): Promise<BazelDocConfiguration> {

--- a/src/bazeldoc/feature.ts
+++ b/src/bazeldoc/feature.ts
@@ -1,16 +1,22 @@
 import * as vscode from 'vscode';
 import { ConfigSection } from './constants';
 import { BazelDocConfiguration, builtInGroups } from './configuration';
-// import { BazelDocGroupHover } from './hover';
+import { BazelDocGroupHover } from './hover';
 import { Reconfigurable } from '../reconfigurable';
 
 export const BazelDocFeatureName = 'bsv.bazeldoc';
+
+// this was an early feature; now that we have better LSP completion support,
+// these hovers are just annoying.
+const useBazelDocGroupHover = false;
 
 export class BazelDocFeature extends Reconfigurable<BazelDocConfiguration> {
   constructor() {
     super(BazelDocFeatureName);
 
-    //this.add(new BazelDocGroupHover(this.onDidConfigurationChange.event));
+    if (useBazelDocGroupHover) {
+      this.add(new BazelDocGroupHover(this.onDidConfigurationChange.event));
+    }
   }
 
   protected async configure(config: vscode.WorkspaceConfiguration): Promise<BazelDocConfiguration> {

--- a/src/bezel/constants.ts
+++ b/src/bezel/constants.ts
@@ -47,6 +47,7 @@ export enum CommandName {
   CodesearchIndex = 'bsv.bzl.codesearch.index',
   CodesearchSearch = 'bsv.bzl.codesearch.search',
   CopyLabel = 'bsv.bzl.copyLabel',
+  GoToLabel = 'bsv.bzl.goToLabel',
   CopyToClipboard = 'bsv.bzl.copyToClipboard',
   DebugBuild = 'bsv.bzl.debugBuild',
   AskForDebugTargetLabel = 'bsv.bzl.askForDebugTargetLabel',

--- a/src/bezel/feature.ts
+++ b/src/bezel/feature.ts
@@ -32,10 +32,10 @@ import { StarlarkDebugger } from './debugger';
 import { RunnableComponent, Status } from './status';
 import { Settings } from './settings';
 import { BuildozerSettings } from '../buildozer/settings';
-import { Buildozer } from '../buildozer/buildozer';
-import { ConfigurationContext, ConfigurationPropertyMap } from '../common';
+import { ConfigurationContext } from '../common';
 import findUp = require('find-up');
 import path = require('path');
+import { Buildozer } from '../buildozer/buildozer';
 
 export const BzlFeatureName = 'bsv.bzl';
 

--- a/src/buildifier/buildifier.ts
+++ b/src/buildifier/buildifier.ts
@@ -18,5 +18,5 @@ export class Buildifier extends RunnableComponent<BuildifierConfiguration> {
     await this.settings.get();
   }
 
-  async stopInternal(): Promise<void> {}
+  async stopInternal(): Promise<void> { }
 }

--- a/src/buildifier/formatter.ts
+++ b/src/buildifier/formatter.ts
@@ -70,7 +70,9 @@ export class BuildifierFormatter implements vscode.DocumentFormattingEditProvide
         ),
       ];
     } catch (err) {
-      vscode.window.showErrorMessage(`buildifier format error: ${err}`);
+      // linter should report the syntactic error, ignore this for the user, but
+      // report debugging info
+      console.warn('buildifier error:', err);
     }
 
     return [];

--- a/src/buildifier/result.ts
+++ b/src/buildifier/result.ts
@@ -23,6 +23,20 @@ export interface IBuildifierResult {
   files: IBuildifierFile[];
 }
 
+/** The result of a single file result from stdin (typical case) */
+export interface IBuildifierStdinResult {
+  /**
+   * Indicates whether or not the check succeeded without finding any problems.
+   */
+  success: boolean;
+
+  /** Information about each file that was checked. */
+  file: IBuildifierFile;
+
+  /** Stderr, if the input was not valid */
+  stderr?: string;
+}
+
 /** Information about a file that was checked by buildifier. */
 export interface IBuildifierFile {
   /** The path of the file that was checked. */

--- a/src/test/integration/feature.buildifier.test.ts
+++ b/src/test/integration/feature.buildifier.test.ts
@@ -63,6 +63,7 @@ suite('bsv.buildifier', function () {
     );
     Container.initialize(configCtx, []);
 
+
     const settings = new BuildifierSettings(configCtx, 'bsv.buildifier');
     formatter = new BuildifierFormatter(settings, []);
 


### PR DESCRIPTION
Adds a new input box that accepts a bazel label and moves the active editor to the location (bound to cmd+; by default).

- improve buildifier to create a diagnostic rather than a window message upon parse error.
- disables category hovers on some bazel symbols (to be replaced with LSP completion support).