### PR TITLE
Prepare 1.5.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
     "name": "bazel-stack-vscode",
     "displayName": "bazel-stack-vscode",
     "description": "Bazel Support for Visual Studio Code",
-    "version": "1.4.0",
+    "version": "1.5.0",
     "publisher": "StackBuild",
     "license": "Apache-2.0",
     "icon": "stackb-full.png",
@@ -232,7 +232,7 @@
                 },
                 "bsv.bzl.server.release": {
                     "type": "string",
-                    "default": "v1.0.5",
+                    "default": "v1.1.1",
                     "description": "Bzl release version"
                 },
                 "bsv.bzl.server.command": {

--- a/src/bezel/configuration.ts
+++ b/src/bezel/configuration.ts
@@ -253,7 +253,7 @@ export class BzlSettings extends Settings<BzlConfiguration> {
       enabled: config.get<boolean>('enabled', true),
       autoLaunch: config.get<boolean>('autoLaunch', true),
       downloadBaseURL: config.get<string>('downloadBaseUrl', 'https://get.bzl.io'),
-      release: config.get<string>('release', 'v0.9.16'),
+      release: config.get<string>('release', 'v1.1.1'),
       executable: normalize(config.get<string>('executable', '')),
       address: address,
       command: config.get<string[]>('command', ['serve', '--address=${address}']),


### PR DESCRIPTION
- Bump bzl version to 1.1.1 (with completion support)