### PR TITLE
Debug improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,7 +159,7 @@ languages.  Supported features include:
     withing the transitive set of source files required to build `[LABEL]`.
   - `ui`: clicking on this code action will open an external link to the
     `[LABEL]` in the [Bzl UI](#bzl-ui-tool).
-- **hover**: 
+- **hover**:
   - hover over a rule/provider/aspect to get documentation about the it (e.g. `ge*nrule`).
   - hover over a rule attribute to get documentation about the attribute (e.g.
     `s*rcs = ["...]`).
@@ -269,7 +269,7 @@ details.
 
 ### Build Events Service Tool
 
-The build event service configured the display of build events within VSCode. 
+The build event service configured the display of build events within VSCode.
 
 ### Invocations Service Tool
 
@@ -285,4 +285,3 @@ invocations.
 
 - syntax highlighting
 - hover to get [flag reference](#Hover-Flags-to-Get-Inline-Documentation) & links to bazel docs / bazel codesearch
-    

--- a/docs/debugging.md
+++ b/docs/debugging.md
@@ -41,9 +41,13 @@ To start the debug session, press `F5` or click on associated **Run and Debug** 
 
 <img width="1290" alt="Screen Shot 2021-10-23 at 9 40 02 PM" src="https://user-images.githubusercontent.com/50580/138579566-4171e37a-1e95-49ef-b5da-36e208a10cde.png">
 
-Note that the `bazel build //:buildifier --experimental_skylark_debug` has been started in an integrated VSCode terminal.  You should keep an eye on this terminal.  
+Note that the `bazel build //:buildifier --experimental_skylark_debug` has been
+started in an integrated VSCode terminal.  You should keep an eye on this
+terminal.  
 
-For example, one reason that a debug session is immediately terminating is that the build files have already been parsed and remain cached by bazel's incrementality model.
+For example, one reason that a debug session is immediately terminating is that
+the build files have already been parsed and remain cached by bazel's
+incrementality model.
 
 You will likely want to make manual changes to the `.bzl` file of interest while
 debugging to force bazel to re-evaluate that file and allow the debugger to
@@ -85,9 +89,11 @@ To run an `attach` debug session, create a corresponding attach configuration:
         },
 ```
 
-The `"debugServer": 4711` part is the default so it's not explicitly required.  This is the TCP port VSCode will use to communicate with the debug adapter.
+The `"debugServer": 4711` part is the default so it's not explicitly required.
+This is the TCP port VSCode will use to communicate with the debug adapter.
 
-To launch the adapter, run `bzl debug adapter`, or launch it from the component activity panel:
+To launch the adapter, run `bzl debug adapter`, or launch it from the component
+activity panel:
 
 <img width="1290" alt="Screen Shot 2021-10-23 at 10 01 56 PM" src="https://user-images.githubusercontent.com/50580/138580187-5e68a8ce-c61c-4908-9d89-4fc5d8253494.png">
 
@@ -95,17 +101,35 @@ This will start the debug adapter in an integrated terminal.
 
 <img width="1290" alt="Screen Shot 2021-10-23 at 10 02 06 PM" src="https://user-images.githubusercontent.com/50580/138580191-6488cd46-20fa-47d2-8fea-188020aeeb3c.png">
 
-At this point, you'll need to manually run a `bazel build //something --experimental_skylark_debug` in the terminal of your choice.
+At this point, you'll need to manually run a `bazel build //something
+--experimental_skylark_debug` in the terminal of your choice.
 
 Then, `F5` and start a debug session using the selected debug configuration.
 
+> NOTE: see below regarding the `DEFAULT.WORKSPACE` file.  Since the debug
+> adapter will run a `bazel query` upon startup, you should always start the
+> adapter before `--experimental_skylark_debug` (the server will be holding the
+> workspace LOCK waiting for a client to attach; while the client is waiting for
+> the LOCK to be released for the bazel query).
+
 ## DEFAULT.WORKSPACE
 
-When a debug session starts from a clean slate, the starlark interpreter starts by parsing your `WORKSPACE` file.
+When a debug session starts from a clean slate, the starlark interpreter starts
+by parsing your `WORKSPACE` file.
 
 Internally, bazel adds extra content to the front and back of your workspace
 before actually slicing it into chunks (delimited by `load()` statements).
 
-While the `/DEFAULT.WORKSPACE` and `/DEFAULT.WORKSPACE.SUFFIX` files only really exist in memory, for the sake of the debug experience, we can "fake" it by writing a mocks of these onto disk.
+While the `/DEFAULT.WORKSPACE` and `/DEFAULT.WORKSPACE.SUFFIX` files only really
+exist in memory, for the sake of the debug experience, we can "fake" it by
+writing a mocks of these onto disk.
 
-To prepare these files, run `bzl debug default_workspace_content`.  They are hardcoded to reside at `${workspace}/.bazel-out/DEFAULT.WORKSPACE`.  If you don't have the `.bazel-out/` symlinks, it might not work.
+The files will be prepared automatically at `${bazel-bin}/DEFAULT.WORKSPACE` and
+`${bazel-bin}/DEFAULT.WORKSPACE.SUFFIX`. The files are prepared via running
+`bazel query //external:* --output build` and shifting the rules into their
+corresponding line locations.
+
+The issue that might trip you up is
+
+To skip this part, run `bzl debug adapter
+--make_default_workspace_content=false`.

--- a/package.json
+++ b/package.json
@@ -544,6 +544,12 @@
             },
             {
                 "category": "Bzl",
+                "command": "bsv.bzl.askForDebugTargetLabel",
+                "title": "Collect bazel debug label",
+                "icon": "$(question)"
+            },
+            {
+                "category": "Bzl",
                 "command": "bsv.bzl.server.launch",
                 "title": "Launch Bzl Server",
                 "icon": "$(play)"

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
     "name": "bazel-stack-vscode",
     "displayName": "bazel-stack-vscode",
     "description": "Bazel Support for Visual Studio Code",
-    "version": "1.5.0",
+    "version": "1.6.0",
     "publisher": "StackBuild",
     "license": "Apache-2.0",
     "icon": "stackb-full.png",
@@ -234,7 +234,7 @@
                 },
                 "bsv.bzl.server.release": {
                     "type": "string",
-                    "default": "v1.1.1",
+                    "default": "v1.1.2",
                     "description": "Bzl release version"
                 },
                 "bsv.bzl.server.command": {
@@ -653,7 +653,7 @@
             "bazel-explorer": [
                 {
                     "id": "bsv.workspace",
-                    "name": "Stack VSCode v1.5.0",
+                    "name": "Stack VSCode v1.6.0",
                     "icon": "media/bazel-wireframe.svg",
                     "contextualTitle": "Current Bazel Workspace",
                     "when": "resourceLangId == bazel"

--- a/src/bezel/configuration.ts
+++ b/src/bezel/configuration.ts
@@ -253,7 +253,7 @@ export class BzlSettings extends Settings<BzlConfiguration> {
       enabled: config.get<boolean>('enabled', true),
       autoLaunch: config.get<boolean>('autoLaunch', true),
       downloadBaseURL: config.get<string>('downloadBaseUrl', 'https://get.bzl.io'),
-      release: config.get<string>('release', 'v1.1.1'),
+      release: config.get<string>('release', 'v1.1.2'),
       executable: normalize(config.get<string>('executable', '')),
       address: address,
       command: config.get<string[]>('command', ['serve', '--address=${address}']),

--- a/src/bezel/debugger.ts
+++ b/src/bezel/debugger.ts
@@ -180,6 +180,13 @@ export class StarlarkDebugger
       return;
     }
 
+    // launch the debug adapter if it not already running
+    if (this.status !== Status.READY && this.status !== Status.DISABLED) {
+      // this needs to wait until the thing is actually running!
+      await this.handleCommandLaunch();
+      this.restart();
+    }
+
     // launch the bazel debugger if this is a launch config
     if (config.request === 'launch') {
       const bazelSettings = await this.bazelSettings.get();
@@ -188,13 +195,6 @@ export class StarlarkDebugger
 
       await vscode.commands.executeCommand(CommandName.Invoke,
         ['build', targetLabel, ...flags, ...extraFlags].filter(arg => isDefined(arg)));
-    }
-
-    // launch the debug adapter if it not already running
-    if (this.status !== Status.READY && this.status !== Status.DISABLED) {
-      // this needs to wait until the thing is actually running!
-      await this.handleCommandLaunch();
-      this.restart();
     }
 
     return config;


### PR DESCRIPTION
- Fix bsv.bzl.askForDebugTargetLabel
- Bump bzl debug adapter (automatically creates DEFAULT.WORKSPACE file(s))
- Bump version ot 1.6.0
- Change ordering of adapter launch (do it first)