### PR TITLE
Propagate lint file directory as cwd to buildifier

### DIFF
--- a/src/buildifier/diagnostics.ts
+++ b/src/buildifier/diagnostics.ts
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+import path = require('path');
 import * as vscode from 'vscode';
 import { buildifierLint, getBuildifierFileType } from './execute';
 import { IBuildifierWarning } from './result';
@@ -96,6 +97,7 @@ export class BuildifierDiagnosticsManager {
 
     const result = await buildifierLint(
       cfg,
+      path.dirname(document.uri.fsPath),
       document.getText(),
       getBuildifierFileType(document.uri.fsPath),
       'warn'

--- a/src/buildifier/execute.ts
+++ b/src/buildifier/execute.ts
@@ -36,6 +36,7 @@ export type BuildifierFileType = 'build' | 'bzl' | 'workspace';
  */
 export async function buildifierFormat(
   cfg: BuildifierConfiguration,
+  cwd: string,
   fileContent: string,
   type: BuildifierFileType,
   applyLintFixes: boolean
@@ -44,7 +45,7 @@ export async function buildifierFormat(
   if (applyLintFixes) {
     args.push('--lint=fix');
   }
-  return (await executeBuildifier(cfg, fileContent, args, false)).stdout;
+  return (await executeBuildifier(cfg, cwd, fileContent, args, false)).stdout;
 }
 
 /**
@@ -60,6 +61,7 @@ export async function buildifierFormat(
  */
 export async function buildifierLint(
   cfg: BuildifierConfiguration,
+  cwd: string,
   fileContent: string,
   type: BuildifierFileType,
   lintMode: 'fix'
@@ -78,6 +80,7 @@ export async function buildifierLint(
  */
 export async function buildifierLint(
   cfg: BuildifierConfiguration,
+  cwd: string,
   fileContent: string,
   type: BuildifierFileType,
   lintMode: 'warn'
@@ -85,12 +88,13 @@ export async function buildifierLint(
 
 export async function buildifierLint(
   cfg: BuildifierConfiguration,
+  cwd: string,
   fileContent: string,
   type: BuildifierFileType,
   lintMode: BuildifierLintMode
 ): Promise<string | IBuildifierStdinResult> {
   const args = ['--format=json', '--mode=check', `--type=${type}`, `--lint=${lintMode}`];
-  const outputs = await executeBuildifier(cfg, fileContent, args, true);
+  const outputs = await executeBuildifier(cfg, cwd, fileContent, args, true);
   switch (lintMode) {
     case 'fix':
       return outputs.stdout;
@@ -174,6 +178,7 @@ export function getBuildifierFileType(fsPath: string): BuildifierFileType {
  */
 function executeBuildifier(
   cfg: BuildifierConfiguration,
+  cwd: string,
   fileContent: string,
   args: string[],
   acceptNonSevereErrors: boolean
@@ -181,6 +186,7 @@ function executeBuildifier(
   return new Promise((resolve, reject) => {
     const execOptions = {
       maxBuffer: Number.MAX_SAFE_INTEGER,
+      cwd,
     };
     const process = child_process.execFile(
       cfg.executable!,

--- a/src/buildifier/formatter.ts
+++ b/src/buildifier/formatter.ts
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+import path = require('path');
 import * as vscode from 'vscode';
 import { buildifierFormat, getBuildifierFileType } from './execute';
 import { BuildifierSettings } from './settings';
@@ -56,7 +57,7 @@ export class BuildifierFormatter implements vscode.DocumentFormattingEditProvide
     const fileContent = document.getText();
     const type = getBuildifierFileType(document.uri.fsPath);
     try {
-      const formattedContent = await buildifierFormat(cfg, fileContent, type, cfg.fixOnFormat);
+      const formattedContent = await buildifierFormat(cfg, path.dirname(document.uri.fsPath), fileContent, type, cfg.fixOnFormat);
 
       if (formattedContent === fileContent) {
         // If the file didn't change, return any empty array of edits.


### PR DESCRIPTION
For https://github.com/bazelbuild/buildtools/pull/1080, the process needs to set the current working directory in order to find the `.buildifier.json` file.  This PR adds that support.