### PR TITLE
Update shiki to 0.14.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change Log
 
+## 1.9.4 (Apr 23 2023)
+
+- Update shiki library for codesearch.  Remove theme customizability for simplicity.
+
 ## 1.9.3 (Aug 15 2022)
 
 - Improvement #[https://github.com/stackb/bazel-stack-vscode/pull/120](https://github.com/stackb/bazel-stack-vscode/pull/120)

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "bazel-stack-vscode",
-  "version": "1.9.3",
+  "version": "1.9.4",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "bazel-stack-vscode",
-      "version": "1.9.3",
+      "version": "1.9.4",
       "license": "Apache-2.0",
       "dependencies": {
         "@grpc/grpc-js": "^1.3.4",
@@ -27,8 +27,8 @@
         "rimraf": "^3.0.2",
         "semver": "7.3.5",
         "sha256-file": "1.0.0",
-        "shiki": "^0.2.6",
-        "shiki-themes": "^0.2.6",
+        "shiki": "0.14.1",
+        "shiki-themes": "0.2.7",
         "strip-ansi": "^6.0.0",
         "tmp": "0.2.1",
         "vscode-common": "1.50.0",
@@ -784,6 +784,11 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/ansi-sequence-parser": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/ansi-sequence-parser/-/ansi-sequence-parser-1.1.0.tgz",
+      "integrity": "sha512-lEm8mt52to2fT8GhciPCGeCXACSz2UwIN4X2e2LJSnZ5uAbn2/dsYdOmUXq0AtWS5cpAupysIneExOgH0Vd2TQ=="
     },
     "node_modules/ansi-styles": {
       "version": "3.2.1",
@@ -2953,6 +2958,11 @@
         "json5": "lib/cli.js"
       }
     },
+    "node_modules/jsonc-parser": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/jsonc-parser/-/jsonc-parser-3.2.0.tgz",
+      "integrity": "sha512-gfFQZrcTc8CnKXp6Y4/CBT3fTc0OVuDofpre4aEeEpSBPV5X5v4+Vmx+8snU7RLPrNHPKSgLxGo9YuQzz20o+w=="
+    },
     "node_modules/jsonfile": {
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.0.1.tgz",
@@ -3088,14 +3098,6 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/long/-/long-4.0.0.tgz",
       "integrity": "sha512-XsP+KhQif4bjX1kbuSiySJFNAehNxgLb6hPRGJ9QsUr8ajHkuXGdrHmFUTUUXhDwVX2R5bY4JNZEwbUiMhV+MA=="
-    },
-    "node_modules/lru-cache": {
-      "version": "5.1.1",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
-      "integrity": "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==",
-      "dependencies": {
-        "yallist": "^3.0.2"
-      }
     },
     "node_modules/luxon": {
       "version": "1.24.1",
@@ -3622,14 +3624,6 @@
       },
       "engines": {
         "node": ">=6"
-      }
-    },
-    "node_modules/onigasm": {
-      "version": "2.2.5",
-      "resolved": "https://registry.npmjs.org/onigasm/-/onigasm-2.2.5.tgz",
-      "integrity": "sha512-F+th54mPc0l1lp1ZcFMyL/jTs2Tlq4SqIHKIXGZOR/VkHkF9A7Fr5rRr5+ZG/lWeRsyrClLYRq7s/yFQ/XhWCA==",
-      "dependencies": {
-        "lru-cache": "^5.1.1"
       }
     },
     "node_modules/optionator": {
@@ -4200,46 +4194,40 @@
       }
     },
     "node_modules/shiki": {
-      "version": "0.2.6",
-      "resolved": "https://registry.npmjs.org/shiki/-/shiki-0.2.6.tgz",
-      "integrity": "sha512-QGpzkZN59bingo/h4uJ85gh3QWBZEU7ZB1xFaq4eh2UZUWpOReo3V/7ouVvsZ07E9vblixCyDSrtdyVpg6IZLQ==",
+      "version": "0.14.1",
+      "resolved": "https://registry.npmjs.org/shiki/-/shiki-0.14.1.tgz",
+      "integrity": "sha512-+Jz4nBkCBe0mEDqo1eKRcCdjRtrCjozmcbTUjbPTX7OOJfEbTZzlUWlZtGe3Gb5oV1/jnojhG//YZc3rs9zSEw==",
       "dependencies": {
-        "onigasm": "^2.2.5",
-        "shiki-languages": "^0.2.6",
-        "shiki-themes": "^0.2.6",
-        "vscode-textmate": "^5.2.0"
-      }
-    },
-    "node_modules/shiki-languages": {
-      "version": "0.2.6",
-      "resolved": "https://registry.npmjs.org/shiki-languages/-/shiki-languages-0.2.6.tgz",
-      "integrity": "sha512-k2p+bYTdQbbJZoWeJwOBY3hs4OC5A5wCP+/M8Ksovk1L30HyBpGsn/C2soGy+xKCjU/rm3ofaGyCSttfP3Ztjw==",
-      "dependencies": {
-        "vscode-textmate": "^5.2.0"
+        "ansi-sequence-parser": "^1.1.0",
+        "jsonc-parser": "^3.2.0",
+        "vscode-oniguruma": "^1.7.0",
+        "vscode-textmate": "^8.0.0"
       }
     },
     "node_modules/shiki-themes": {
-      "version": "0.2.6",
-      "resolved": "https://registry.npmjs.org/shiki-themes/-/shiki-themes-0.2.6.tgz",
-      "integrity": "sha512-566UwtYR29zTBEQKbN9v10y+PVSmCsvosoiBoloNBLnTXi1bI7ZjDH+TKkc0+9n9QvJ3kj3IUvmvXL6six1Rhg==",
+      "version": "0.2.7",
+      "resolved": "https://registry.npmjs.org/shiki-themes/-/shiki-themes-0.2.7.tgz",
+      "integrity": "sha512-ZMmboDYw5+SEpugM8KGUq3tkZ0vXg+k60XX6NngDK7gc1Sv6YLUlanpvG3evm57uKJvfXsky/S5MzSOTtYKLjA==",
       "dependencies": {
         "json5": "^2.1.0",
         "vscode-textmate": "^5.2.0"
       }
     },
     "node_modules/shiki-themes/node_modules/json5": {
-      "version": "2.1.3",
-      "resolved": "https://registry.npmjs.org/json5/-/json5-2.1.3.tgz",
-      "integrity": "sha512-KXPvOm8K9IJKFM0bmdn8QXh7udDh1g/giieX0NLCaMnb4hEiVFqnop2ImTXCc5e0/oHz3LTqmHGtExn5hfMkOA==",
-      "dependencies": {
-        "minimist": "^1.2.5"
-      },
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
+      "integrity": "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==",
       "bin": {
         "json5": "lib/cli.js"
       },
       "engines": {
         "node": ">=6"
       }
+    },
+    "node_modules/shiki-themes/node_modules/vscode-textmate": {
+      "version": "5.5.0",
+      "resolved": "https://registry.npmjs.org/vscode-textmate/-/vscode-textmate-5.5.0.tgz",
+      "integrity": "sha512-jToQkPGMNKn0eyKyitYeINJF0NoD240aYyKPIWJv5W2jfPt++jIRg0OSergubtGhbw6SoefkvBYEpX7TsfoSUQ=="
     },
     "node_modules/shimmer": {
       "version": "1.2.1",
@@ -5039,6 +5027,11 @@
       "resolved": "https://registry.npmjs.org/vscode-languageserver-types/-/vscode-languageserver-types-3.16.0.tgz",
       "integrity": "sha512-k8luDIWJWyenLc5ToFQQMaSrqCHiLwyKPHKPQZ5zz21vM+vIVUSvsRpcbiECH4WR88K2XZqc4ScRcZ7nk/jbeA=="
     },
+    "node_modules/vscode-oniguruma": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/vscode-oniguruma/-/vscode-oniguruma-1.7.0.tgz",
+      "integrity": "sha512-L9WMGRfrjOhgHSdOYgCt/yRMsXzLDJSL7BPrOZt73gU0iWO4mpqzqQzOz5srxqTvMBaR0XZTSrVWo4j55Rc6cA=="
+    },
     "node_modules/vscode-test": {
       "version": "1.6.1",
       "resolved": "https://registry.npmjs.org/vscode-test/-/vscode-test-1.6.1.tgz",
@@ -5056,9 +5049,9 @@
       }
     },
     "node_modules/vscode-textmate": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/vscode-textmate/-/vscode-textmate-5.2.0.tgz",
-      "integrity": "sha512-Uw5ooOQxRASHgu6C7GVvUxisKXfSgW4oFlO+aa+PAkgmH89O3CXxEEzNRNtHSqtXFTl0nAC1uYj0GMSH27uwtQ=="
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/vscode-textmate/-/vscode-textmate-8.0.0.tgz",
+      "integrity": "sha512-AFbieoL7a5LMqcnOF04ji+rpXadgOXnZsxQr//r83kLPr7biP7am3g9zbaZIaBGwBRWeSvoMD4mgPdX3e4NWBg=="
     },
     "node_modules/which": {
       "version": "1.3.1",
@@ -5247,11 +5240,6 @@
       "resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.3.tgz",
       "integrity": "sha512-JKhqTOwSrqNA1NY5lSztJ1GrBiUodLMmIZuLiDaMRJ+itFd+ABVE8XBjOvIWL+rSqNDC74LCSFmlb/U4UZ4hJQ==",
       "dev": true
-    },
-    "node_modules/yallist": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
-      "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g=="
     },
     "node_modules/yargs": {
       "version": "13.3.2",
@@ -6068,6 +6056,11 @@
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.0.tgz",
       "integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg=="
+    },
+    "ansi-sequence-parser": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/ansi-sequence-parser/-/ansi-sequence-parser-1.1.0.tgz",
+      "integrity": "sha512-lEm8mt52to2fT8GhciPCGeCXACSz2UwIN4X2e2LJSnZ5uAbn2/dsYdOmUXq0AtWS5cpAupysIneExOgH0Vd2TQ=="
     },
     "ansi-styles": {
       "version": "3.2.1",
@@ -7782,6 +7775,11 @@
         "minimist": "^1.2.0"
       }
     },
+    "jsonc-parser": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/jsonc-parser/-/jsonc-parser-3.2.0.tgz",
+      "integrity": "sha512-gfFQZrcTc8CnKXp6Y4/CBT3fTc0OVuDofpre4aEeEpSBPV5X5v4+Vmx+8snU7RLPrNHPKSgLxGo9YuQzz20o+w=="
+    },
     "jsonfile": {
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.0.1.tgz",
@@ -7898,14 +7896,6 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/long/-/long-4.0.0.tgz",
       "integrity": "sha512-XsP+KhQif4bjX1kbuSiySJFNAehNxgLb6hPRGJ9QsUr8ajHkuXGdrHmFUTUUXhDwVX2R5bY4JNZEwbUiMhV+MA=="
-    },
-    "lru-cache": {
-      "version": "5.1.1",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
-      "integrity": "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==",
-      "requires": {
-        "yallist": "^3.0.2"
-      }
     },
     "luxon": {
       "version": "1.24.1",
@@ -8329,14 +8319,6 @@
       "dev": true,
       "requires": {
         "mimic-fn": "^2.1.0"
-      }
-    },
-    "onigasm": {
-      "version": "2.2.5",
-      "resolved": "https://registry.npmjs.org/onigasm/-/onigasm-2.2.5.tgz",
-      "integrity": "sha512-F+th54mPc0l1lp1ZcFMyL/jTs2Tlq4SqIHKIXGZOR/VkHkF9A7Fr5rRr5+ZG/lWeRsyrClLYRq7s/yFQ/XhWCA==",
-      "requires": {
-        "lru-cache": "^5.1.1"
       }
     },
     "optionator": {
@@ -8798,40 +8780,34 @@
       "dev": true
     },
     "shiki": {
-      "version": "0.2.6",
-      "resolved": "https://registry.npmjs.org/shiki/-/shiki-0.2.6.tgz",
-      "integrity": "sha512-QGpzkZN59bingo/h4uJ85gh3QWBZEU7ZB1xFaq4eh2UZUWpOReo3V/7ouVvsZ07E9vblixCyDSrtdyVpg6IZLQ==",
+      "version": "0.14.1",
+      "resolved": "https://registry.npmjs.org/shiki/-/shiki-0.14.1.tgz",
+      "integrity": "sha512-+Jz4nBkCBe0mEDqo1eKRcCdjRtrCjozmcbTUjbPTX7OOJfEbTZzlUWlZtGe3Gb5oV1/jnojhG//YZc3rs9zSEw==",
       "requires": {
-        "onigasm": "^2.2.5",
-        "shiki-languages": "^0.2.6",
-        "shiki-themes": "^0.2.6",
-        "vscode-textmate": "^5.2.0"
-      }
-    },
-    "shiki-languages": {
-      "version": "0.2.6",
-      "resolved": "https://registry.npmjs.org/shiki-languages/-/shiki-languages-0.2.6.tgz",
-      "integrity": "sha512-k2p+bYTdQbbJZoWeJwOBY3hs4OC5A5wCP+/M8Ksovk1L30HyBpGsn/C2soGy+xKCjU/rm3ofaGyCSttfP3Ztjw==",
-      "requires": {
-        "vscode-textmate": "^5.2.0"
+        "ansi-sequence-parser": "^1.1.0",
+        "jsonc-parser": "^3.2.0",
+        "vscode-oniguruma": "^1.7.0",
+        "vscode-textmate": "^8.0.0"
       }
     },
     "shiki-themes": {
-      "version": "0.2.6",
-      "resolved": "https://registry.npmjs.org/shiki-themes/-/shiki-themes-0.2.6.tgz",
-      "integrity": "sha512-566UwtYR29zTBEQKbN9v10y+PVSmCsvosoiBoloNBLnTXi1bI7ZjDH+TKkc0+9n9QvJ3kj3IUvmvXL6six1Rhg==",
+      "version": "0.2.7",
+      "resolved": "https://registry.npmjs.org/shiki-themes/-/shiki-themes-0.2.7.tgz",
+      "integrity": "sha512-ZMmboDYw5+SEpugM8KGUq3tkZ0vXg+k60XX6NngDK7gc1Sv6YLUlanpvG3evm57uKJvfXsky/S5MzSOTtYKLjA==",
       "requires": {
         "json5": "^2.1.0",
         "vscode-textmate": "^5.2.0"
       },
       "dependencies": {
         "json5": {
-          "version": "2.1.3",
-          "resolved": "https://registry.npmjs.org/json5/-/json5-2.1.3.tgz",
-          "integrity": "sha512-KXPvOm8K9IJKFM0bmdn8QXh7udDh1g/giieX0NLCaMnb4hEiVFqnop2ImTXCc5e0/oHz3LTqmHGtExn5hfMkOA==",
-          "requires": {
-            "minimist": "^1.2.5"
-          }
+          "version": "2.2.3",
+          "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
+          "integrity": "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg=="
+        },
+        "vscode-textmate": {
+          "version": "5.5.0",
+          "resolved": "https://registry.npmjs.org/vscode-textmate/-/vscode-textmate-5.5.0.tgz",
+          "integrity": "sha512-jToQkPGMNKn0eyKyitYeINJF0NoD240aYyKPIWJv5W2jfPt++jIRg0OSergubtGhbw6SoefkvBYEpX7TsfoSUQ=="
         }
       }
     },
@@ -9476,6 +9452,11 @@
       "resolved": "https://registry.npmjs.org/vscode-languageserver-types/-/vscode-languageserver-types-3.16.0.tgz",
       "integrity": "sha512-k8luDIWJWyenLc5ToFQQMaSrqCHiLwyKPHKPQZ5zz21vM+vIVUSvsRpcbiECH4WR88K2XZqc4ScRcZ7nk/jbeA=="
     },
+    "vscode-oniguruma": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/vscode-oniguruma/-/vscode-oniguruma-1.7.0.tgz",
+      "integrity": "sha512-L9WMGRfrjOhgHSdOYgCt/yRMsXzLDJSL7BPrOZt73gU0iWO4mpqzqQzOz5srxqTvMBaR0XZTSrVWo4j55Rc6cA=="
+    },
     "vscode-test": {
       "version": "1.6.1",
       "resolved": "https://registry.npmjs.org/vscode-test/-/vscode-test-1.6.1.tgz",
@@ -9489,9 +9470,9 @@
       }
     },
     "vscode-textmate": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/vscode-textmate/-/vscode-textmate-5.2.0.tgz",
-      "integrity": "sha512-Uw5ooOQxRASHgu6C7GVvUxisKXfSgW4oFlO+aa+PAkgmH89O3CXxEEzNRNtHSqtXFTl0nAC1uYj0GMSH27uwtQ=="
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/vscode-textmate/-/vscode-textmate-8.0.0.tgz",
+      "integrity": "sha512-AFbieoL7a5LMqcnOF04ji+rpXadgOXnZsxQr//r83kLPr7biP7am3g9zbaZIaBGwBRWeSvoMD4mgPdX3e4NWBg=="
     },
     "which": {
       "version": "1.3.1",
@@ -9642,11 +9623,6 @@
       "resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.3.tgz",
       "integrity": "sha512-JKhqTOwSrqNA1NY5lSztJ1GrBiUodLMmIZuLiDaMRJ+itFd+ABVE8XBjOvIWL+rSqNDC74LCSFmlb/U4UZ4hJQ==",
       "dev": true
-    },
-    "yallist": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
-      "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g=="
     },
     "yargs": {
       "version": "13.3.2",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "bazel-stack-vscode",
   "displayName": "bazel-stack-vscode",
   "description": "Bazel Support for Visual Studio Code",
-  "version": "1.9.3",
+  "version": "1.9.4",
   "publisher": "StackBuild",
   "license": "Apache-2.0",
   "icon": "stackb-full.png",
@@ -671,7 +671,7 @@
       "bazel-explorer": [
         {
           "id": "bsv.workspace",
-          "name": "Stack VSCode v1.9.3",
+          "name": "Stack VSCode v1.9.4",
           "icon": "media/bazel-wireframe.svg",
           "contextualTitle": "Current Bazel Workspace"
         }
@@ -781,8 +781,8 @@
     "rimraf": "^3.0.2",
     "semver": "7.3.5",
     "sha256-file": "1.0.0",
-    "shiki-themes": "^0.2.6",
-    "shiki": "^0.2.6",
+    "shiki-themes": "0.2.7",
+    "shiki": "0.14.1",
     "strip-ansi": "^6.0.0",
     "tmp": "0.2.1",
     "vscode-common": "1.50.0",

--- a/src/bezel/codesearch/renderer.ts
+++ b/src/bezel/codesearch/renderer.ts
@@ -1,7 +1,6 @@
 import { IThemedToken } from 'shiki';
 import { IShikiTheme } from 'shiki-themes';
-import { Highlighter } from 'shiki/dist/highlighter';
-import { HtmlRendererOptions } from 'shiki/dist/renderer';
+import { Highlighter, HtmlRendererOptions } from 'shiki';
 import * as vscode from 'vscode';
 import { map, strings } from 'vscode-common';
 import { makeCommandURI } from '../../common';
@@ -44,14 +43,12 @@ export class CodesearchRenderer {
     const atLimit = query.maxMatches === result.results?.length;
     let html = '';
     if (result.results) {
-      html += `<span>${result.results?.length}${atLimit ? '+' : ''} match${
-        result.results.length > 1 ? 'es' : ''
-      }</span>`;
+      html += `<span>${result.results?.length}${atLimit ? '+' : ''} match${result.results.length > 1 ? 'es' : ''
+        }</span>`;
     }
     if (result.fileResults) {
-      html += ` (<span>${result.fileResults?.length} filename match${
-        result.fileResults.length > 1 ? 'es' : ''
-      }</span>)`;
+      html += ` (<span>${result.fileResults?.length} filename match${result.fileResults.length > 1 ? 'es' : ''
+        }</span>)`;
     }
     if (html === '') {
       html = 'No results.';
@@ -62,9 +59,12 @@ export class CodesearchRenderer {
   public async renderResults(result: CodeSearchResult, workspace: Workspace): Promise<string> {
     const merge = mergeCodeSearchResult(result);
     const highlighter = await this._highlighter.getHighlighter();
-    const theme = this._highlighter.getCurrentTheme();
-    if (!(highlighter && theme)) {
-      return 'N/A';
+    if (!highlighter) {
+      return 'ERROR: Syntax highlighter failed to initialize';
+    }
+    const theme = await this._highlighter.getCurrentTheme();
+    if (!theme) {
+      return 'ERROR: Syntax highlighter theme failed to initialize.';
     }
 
     let lines: string[] = [];
@@ -133,13 +133,13 @@ export class CodesearchRenderer {
 		<div class="peek-view-title">
 			<label>${baseName}</label>
 			<span class="peek-view-title-description">${getDisplayFilename(
-        path.dirname(result.path!),
-        workspace
-      )}</span>
+      path.dirname(result.path!),
+      workspace
+    )}</span>
 			<span style="float: right; margin-right: 0.5rem" class="peek-view-title-description">${getDisplayLanguageName(
-        lang,
-        baseName
-      )}</span>
+      lang,
+      baseName
+    )}</span>
 		</div>
 		`);
 
@@ -151,10 +151,8 @@ export class CodesearchRenderer {
       for (const line of block.lines || []) {
         const lineNo = Long.fromValue(line.lineNumber || 0).toInt();
         lines.push(
-          `<tr class="linerow" onclick="postDataElementClick('line', this)" data-file="${
-            result.path
-          }" data-line="${lineNo}" data-col="0"><td class="lineno ${
-            line.bounds?.length ? 'activelineno' : ''
+          `<tr class="linerow" onclick="postDataElementClick('line', this)" data-file="${result.path
+          }" data-line="${lineNo}" data-col="0"><td class="lineno ${line.bounds?.length ? 'activelineno' : ''
           }">${lineNo}</td><td class="line-container">`
         );
         const html = formatLineBounds(line, lang, highlighter, theme);


### PR DESCRIPTION
Fix extension loading error due to outdated shiki library version.

- Bump shiki to 0.14.0
- Simplify / hardcode theme selection.
- Bump to extension version to 1.9.4
